### PR TITLE
Fix links to templates in experimental design readme

### DIFF
--- a/experimental-design/README.adoc
+++ b/experimental-design/README.adoc
@@ -269,12 +269,12 @@ Some of the most popular labels are:
 
 The *sample metadata templates* are a set of guidelines to annotate different type of proteomics experiments to ensure that a Minimum Metadata and `characteristics` are provided to understand the dataset. These templates respond to the distribution and frequency of experiment types in public databases like http://www.ebi.ac.uk/pride/archive[PRIDE] and http://www.proteomexchange.org/[ProteomeXchange]:
 
-- Default: Minimum information for any proteomics experiment https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-default.txt[Template]
-- Human: All tissue-based experiments that use Human samples https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-human.txt[Template]
-- Vertebrates: Vertebrate experiment. https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-vertebrates.txt[Template]
-- Non-vertebrates: Non-vertebrate experiment. https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-nonvertebrates.txt[Template]
-- Plants: Plant experiment. https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-plants.txt[Template]
-- Cell lines: Experiments using cell-lines. https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-cell-line.txt[Template]
+- Default: Minimum information for any proteomics experiment https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-default.tsv[Template]
+- Human: All tissue-based experiments that use Human samples https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-human.tsv[Template]
+- Vertebrates: Vertebrate experiment. https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-vertebrates.tsv[Template]
+- Non-vertebrates: Non-vertebrate experiment. https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-nonvertebrates.tsv[Template]
+- Plants: Plant experiment. https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-plants.tsv[Template]
+- Cell lines: Experiments using cell-lines. https://github.com/bigbio/proteomics-metadata-standard/blob/master/templates/sdrf-cell-line.tsv[Template]
 
 *Sample attributes*: Minimum sample attributes for primary cells from different species and cell lines
 


### PR DESCRIPTION
The [Readme on Experimental Design](https://github.com/bigbio/proteomics-metadata-standard/tree/master/experimental-design#5-samplemsrun-templates) has links to template files that are currently broken. This fixes the URLs by changing `txt` extensions to `tsv`.