### PR TITLE
Add validation script

### DIFF
--- a/validate-all.py
+++ b/validate-all.py
@@ -3,6 +3,7 @@
 import os
 import glob
 import sys
+import argparse
 from sdrf_pipelines.sdrf import sdrf, sdrf_schema
 DIR = 'annotated-projects'
 VALIDATE = ['parse_sdrf', 'validate-sdrf']
@@ -19,10 +20,11 @@ def get_template(df):
         return sdrf_schema.HUMAN_TEMPLATE
 
 
-def main():
+def main(args):
     status = []
     for project in projects:
         sdrf_files = glob.glob(os.path.join(DIR, project, '*.tsv'))
+        errors = []
         if sdrf_files:
             result = 'OK'
             for sdrf_file in sdrf_files:
@@ -41,6 +43,9 @@ def main():
         else:
             result = 'SDRF file not found'
         status.append(result)
+        if args.verbose:
+            for err in errors:
+                print(err)
         print(project, result, sep='\t')
     errors = 0
     print('Final results:')
@@ -52,5 +57,8 @@ def main():
 
 
 if __name__ == '__main__':
-    out = main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-v', '--verbose', action='store_true', help='Print all errors.')
+    args = parser.parse_args()
+    out = main(args)
     sys.exit(out)

--- a/validate-all.py
+++ b/validate-all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import glob
@@ -40,6 +40,10 @@ def main(args):
                         if errors:
                             result = 'Failed validation for {}'.format(template)
                             break
+                    errors = df.validate(sdrf_schema.MASS_SPECTROMETRY)
+                    if errors:
+                        result = 'Failed mass spectrometry validation'
+                        break
         else:
             result = 'SDRF file not found'
         status.append(result)

--- a/validate-all.py
+++ b/validate-all.py
@@ -13,11 +13,10 @@ projects = os.listdir(DIR)
 def get_template(df):
     """Extract organism information and pick a template for validation"""
     organisms = df['characteristics[organism]'].unique()
-    if organisms.size > 1:
-        return None
-    organism = organisms[0].lower()
-    if organism == 'homo sapiens':
-        return sdrf_schema.HUMAN_TEMPLATE
+    templates = []
+    if 'homo sapiens' in organisms:
+        templates.append(sdrf_schema.HUMAN_TEMPLATE)
+    return templates
 
 
 def main(args):
@@ -34,12 +33,15 @@ def main(args):
                     result = 'Failed basic validation'
                     break
                 else:
-                    template = get_template(df)
-                    if template:
-                        errors = df.validate(template)
-                        if errors:
-                            result = 'Failed validation for {}'.format(template)
-                            break
+                    templates = get_template(df)
+                    if templates:
+                        for t in templates:
+                            errors = df.validate(t)
+                            if errors:
+                                result = 'Failed validation for {}'.format(t)
+                                break
+                    if errors:
+                        break
                     errors = df.validate(sdrf_schema.MASS_SPECTROMETRY)
                     if errors:
                         result = 'Failed mass spectrometry validation'

--- a/validate-all.py
+++ b/validate-all.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+
+import os
+import glob
+import sys
+from sdrf_pipelines.sdrf import sdrf, sdrf_schema
+DIR = 'annotated-projects'
+VALIDATE = ['parse_sdrf', 'validate-sdrf']
+projects = os.listdir(DIR)
+
+
+def get_template(df):
+    """Extract organism information and pick a template for validation"""
+    organisms = df['characteristics[organism]'].unique()
+    if organisms.size > 1:
+        return None
+    organism = organisms[0].lower()
+    if organism == 'homo sapiens':
+        return sdrf_schema.HUMAN_TEMPLATE
+
+
+def main():
+    status = []
+    for project in projects:
+        sdrf_files = glob.glob(os.path.join(DIR, project, '*.tsv'))
+        if sdrf_files:
+            result = 'OK'
+            for sdrf_file in sdrf_files:
+                df = sdrf.SdrfDataFrame.parse(sdrf_file)
+                errors = df.validate(sdrf_schema.DEFAULT_TEMPLATE)
+                if errors:
+                    result = 'Failed basic validation'
+                    break
+                else:
+                    template = get_template(df)
+                    if template:
+                        errors = df.validate(template)
+                        if errors:
+                            result = 'Failed validation for {}'.format(template)
+                            break
+        else:
+            result = 'SDRF file not found'
+        status.append(result)
+        print(project, result, sep='\t')
+    errors = 0
+    print('Final results:')
+    for project, result in zip(projects, status):
+        if result != 'OK':
+            errors += 1
+    print('Total: {} projects checked, {} had validation errors.'.format(len(projects), errors))
+    return errors
+
+
+if __name__ == '__main__':
+    out = main()
+    sys.exit(out)


### PR DESCRIPTION
This PR simply adds a helper Python script that validates all annotated projects with `sdrf_pipelines`. If the organism is `homo sapiens`, it checks against the human template. More elaborate organism selection can be added later.

This script can later be used in CI for this project as suggested in #222, but for now every dataset fails the validation.