### PR TITLE
validator do not fail if sdrf.tsv is not found in folder.

### DIFF
--- a/validate-all.py
+++ b/validate-all.py
@@ -88,7 +88,7 @@ def main(args):
     errors = 0
     print('Final results:')
     for project, result in zip(projects, status):
-        if result != 'OK' or result != 'SDRF file not found':
+        if result != 'OK' and result != 'SDRF file not found':
             errors += 1
     print('Total: {} projects checked, {} had validation errors.'.format(len(projects), errors))
     return errors


### PR DESCRIPTION
This PR modifies the validator to do not fail if it is not found a proper SDRF file in a folder. We need this to progressively fix all the annotations problems found by the validator. @levitsky I will remove the condition after we finish. 