### PR TITLE
Match all sdrf files in validation script

### DIFF
--- a/validate-all.py
+++ b/validate-all.py
@@ -56,7 +56,7 @@ def get_template(df):
 def main(args):
     status = []
     for project in projects:
-        sdrf_files = glob.glob(os.path.join(DIR, project, '*.tsv'))
+        sdrf_files = glob.glob(os.path.join(DIR, project, 'sdrf*'))
         error_types = set()
         errors = []
         if sdrf_files:
@@ -88,7 +88,7 @@ def main(args):
     errors = 0
     print('Final results:')
     for project, result in zip(projects, status):
-        if result != 'OK' and result != 'SDRF file not found':
+        if result != 'OK':
             errors += 1
     print('Total: {} projects checked, {} had validation errors.'.format(len(projects), errors))
     return errors


### PR DESCRIPTION
This PR changes validation script:

- it matches all files starting with `sdrf`, not just `tsv` files. It will potentially match and validate compressed files, too (discussed in #257);

- also removes the temporary condition that excluded not-found results from error count (#239). This version finds the temporarily renamed files anyway.

**Warning:** The auto-check of subsequent annotations will fail until the remaining annotations are fixed in `master`.