### PR TITLE
Trigger Github action when validation script is changed

### DIFF
--- a/.github/workflows/validate-all.yml
+++ b/.github/workflows/validate-all.yml
@@ -4,12 +4,14 @@ name: Validate annotations
 
 on:
   push:
-    paths: annotated-projects/**
-    paths: validate-*.py
+    paths:
+      - 'annotated-projects/**'
+      - 'validate-*.py'
   pull_request:
     branches: [ master ]
-    paths: annotated-projects/**
-    paths: validate-*.py
+    paths:
+      - 'annotated-projects/**'
+      - 'validate-*.py'
 
 jobs:
   build:

--- a/.github/workflows/validate-all.yml
+++ b/.github/workflows/validate-all.yml
@@ -5,9 +5,11 @@ name: Validate annotations
 on:
   push:
     paths: annotated-projects/**
+    paths: validate-*.py
   pull_request:
     branches: [ master ]
     paths: annotated-projects/**
+    paths: validate-*.py
 
 jobs:
   build:

--- a/validate-all.py
+++ b/validate-all.py
@@ -58,6 +58,7 @@ def main(args):
     for project in projects:
         sdrf_files = glob.glob(os.path.join(DIR, project, 'sdrf*'))
         error_types = set()
+        error_files = set()
         errors = []
         if sdrf_files:
             result = 'OK'
@@ -76,8 +77,10 @@ def main(args):
                     errors.extend(df.validate(sdrf_schema.MASS_SPECTROMETRY))
                     if errors:
                         error_types.add('mass spectrometry')
+                if errors:
+                    error_files.add(os.path.basename(sdrf_file))
             if error_types:
-                result = 'Failed ' + ', '.join(error_types) + ' validation'
+                result = 'Failed ' + ', '.join(error_types) + ' validation ({})'.format(', '.join(error_files))
         else:
             result = 'SDRF file not found'
         status.append(result)


### PR DESCRIPTION
This change makes validation re-run when the validation script is updated. This PR also changes the script itself (makes it print names of files with errors), so it triggers a failing check due to unresolved annotation problems in `master`.