### PR TITLE
Add weeks as possible age/time measure

### DIFF
--- a/experimental-design/README.adoc
+++ b/experimental-design/README.adoc
@@ -115,7 +115,7 @@ The value for each property (e.g. _characteristics_, _comment_) corresponding to
 [[encoding-age]]
 === How to encode age
 
-One of the characteristics about the sample is the age of an individual. This specification RECOMMENDED to provide the age in the following format: `{X}Y{X}M{X}D`. Some valid examples are:
+One of the characteristics about the sample is the age of an individual. It is RECOMMENDED to provide the age in the following format: `{X}Y{X}M{X}D`. Some valid examples are:
 
 - 40Y (forty years)
 - 40Y5M (forty years and 5 months)
@@ -124,6 +124,8 @@ One of the characteristics about the sample is the age of an individual. This sp
 When needed, weeks can also be used:
 
 - 8W (eight weeks)
+
+Other temporal information can be encoded in a similar way.
 
 [[enrichment-phsophorylation-experiment]]
 === Phosphoproteomics and PTMs experiments

--- a/experimental-design/README.adoc
+++ b/experimental-design/README.adoc
@@ -115,11 +115,15 @@ The value for each property (e.g. _characteristics_, _comment_) corresponding to
 [[encoding-age]]
 === How to encode age
 
-One of the characteristics about the sample is the age of an individual. This specification RECOMMENDED to provide the age in the following format: {X}Y{X}M{X}D . Some valid examples are:
+One of the characteristics about the sample is the age of an individual. This specification RECOMMENDED to provide the age in the following format: `{X}Y{X}M{X}D`. Some valid examples are:
 
 - 40Y (forty years)
 - 40Y5M (forty years and 5 months)
 - 40Y5M2D (forty years, 5 months and 2 days)
+
+When needed, weeks can also be used:
+
+- 8W (eight weeks)
 
 [[enrichment-phsophorylation-experiment]]
 === Phosphoproteomics and PTMs experiments


### PR DESCRIPTION
This is a suggestion to allow weeks as age units.

To be honest, this is not because I have found a project where annotation requires this. However, I am annotating a project where samples are attributed sampling time in weeks. I feel like this should preferably be in the same format as age.

We should probably add a general recommendation for other temporal information as well as age (included in this PR).

I don't feel comfortable converting weeks to days because days imply more accuracy.