### PR TITLE
Detect cell line template; report used templates in validation script

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -6,7 +6,6 @@ import sys
 import argparse
 import logging
 import itertools
-from urllib.error import URLError
 
 from pandas_schema import ValidationWarning
 from sdrf_pipelines.zooma import ols
@@ -22,7 +21,7 @@ def retry(func):
         for i in range(5):
             try:
                 return func(*args, **kwargs)
-            except (KeyError, URLError):
+            except Exception:
                 pass
     return wrapper
 
@@ -115,10 +114,10 @@ def main(args):
         sdrf_files = glob.glob(os.path.join(DIR, project, 'sdrf*'))
         error_types = set()
         error_files = set()
-        errors = []
         if sdrf_files:
             result = 'OK'
             for sdrf_file in sdrf_files:
+                errors = []
                 df = sdrf.SdrfDataFrame.parse(sdrf_file)
                 err = df.validate(sdrf_schema.DEFAULT_TEMPLATE)
                 errors.extend(err)
@@ -143,7 +142,7 @@ def main(args):
             elif has_warnings(errors):
                 result = 'OK (with warnings)'
             if result[:2] == 'OK':
-                result += '\t[{} template]'.format(', '.join(templates))
+                result = '[{} template]\t'.format(', '.join(templates)) + result
         else:
             result = 'SDRF file not found'
         status.append(result)

--- a/validate.py
+++ b/validate.py
@@ -148,7 +148,7 @@ def main(args):
                     result = 'OK (with warnings)'
                     status = 1
                 if status < 2:
-                    result = '[{} template]\t'.format(', '.join(templates)) + result
+                    result = '[{} template]\t'.format(', '.join(templates) if templates else 'default') + result
             else:
                 result = 'SDRF file not found'
             statuses.append(status)


### PR DESCRIPTION
Fixes #330.

This PR changes the validation script so that it looks for `cultured cell` and applies cell line template where appropriate.

<s>The check on this PR should fail, due to:
1. The PR changing the validation script, triggering a complete check of all annotated projects;
2. 3 annotated projects missing the cell type column.</s>