### PR TITLE
Add optional precursor mass/charge/RT/IM range columns to DDA/DIA template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ site/sdrf-data.json
 # Claude Code #
 ###############
 .claude/
+CLAUDE.md
 .codacy/
 
 # Local files for developers are in folder in local-info

--- a/sdrf-proteomics/metadata-guidelines/sdrf-terms.tsv
+++ b/sdrf-proteomics/metadata-guidelines/sdrf-terms.tsv
@@ -76,8 +76,14 @@ data file	comment	MS:1000577	minimum, default, human, cell-lines, single-cell, i
 modification parameters	comment	MS:1001055	dia-acquisition, dda-acquisition	Unimod, PSI-MOD	Post-translational modifications searched	true	false	false
 precursor mass tolerance	comment	PRIDE:0000575	dia-acquisition, dda-acquisition	pattern: number + ppm/Da	Precursor mass tolerance for database search	true	true	false
 fragment mass tolerance	comment	PRIDE:0000576	dia-acquisition, dda-acquisition	pattern: number + ppm/Da	Fragment mass tolerance for database search	true	true	false
-precursor mass range	comment	to be filled	dda-acquisition	pattern: number:number (Da)	Precursor mass range for database search (e.g., 800:2500)	true	true	false
-precursor charge range	comment	to be filled	dda-acquisition	pattern: number:number	Precursor charge range for database search (e.g., 1:3)	true	true	false
+precursor min mz	comment	PRIDE:0000476	dia-acquisition, dda-acquisition	numeric (m/z)	MS method-defined minimum precursor m/z setting used to acquire the data	true	true	false
+precursor max mz	comment	PRIDE:0000477	dia-acquisition, dda-acquisition	numeric (m/z)	MS method-defined maximum precursor m/z setting used to acquire the data	true	true	false
+precursor min charge	comment	PRIDE:0000472	dia-acquisition, dda-acquisition	integer	MS method-defined minimum precursor charge state setting used to acquire the data	true	true	false
+precursor max charge	comment	PRIDE:0000473	dia-acquisition, dda-acquisition	integer	MS method-defined maximum precursor charge state setting used to acquire the data	true	true	false
+min retention time	comment	PRIDE:0000474	dia-acquisition, dda-acquisition	numeric (minutes)	LC method-defined minimum retention time setting used to acquire the data	true	true	false
+max retention time	comment	PRIDE:0000475	dia-acquisition, dda-acquisition	numeric (minutes)	LC method-defined maximum retention time setting used to acquire the data	true	true	false
+min ion mobility	comment	PRIDE:0000841	dia-acquisition, dda-acquisition	numeric (1/K0 or Vs/cm2)	MS method-defined minimum ion mobility setting used to acquire the data	true	true	false
+max ion mobility	comment	PRIDE:0000842	dia-acquisition, dda-acquisition	numeric (1/K0 or Vs/cm2)	MS method-defined maximum ion mobility setting used to acquire the data	true	true	false
 passage number	comment	to be filled	cell-lines	integer or range	Passage number of the cell line	true	true	false
 cell line source	comment	to be filled	cell-lines	free text	Repository or source from which the cell line was obtained	true	true	false
 authentication method	comment	to be filled	cell-lines	free text	Method used to authenticate the cell line identity	true	true	false

--- a/sdrf-proteomics/templates/dda-acquisition/README.adoc
+++ b/sdrf-proteomics/templates/dda-acquisition/README.adoc
@@ -126,18 +126,60 @@ ifdef::backend-html5[]
 <td>NT=orbitrap;AC=MS:1000484</td>
 </tr>
 <tr>
-<td><code>comment[precursor mass range]</code></td>
+<td><code>comment[precursor min mz]</code></td>
 <td><span class="optional-badge">OPTIONAL</span></td>
-<td>Precursor mass range used for database search</td>
-<td>Numeric range in Da</td>
-<td>800:2500, 800:5000</td>
+<td>MS method-defined minimum precursor m/z setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000476">PRIDE (PRIDE:0000476)</a></td>
+<td>350, 400</td>
 </tr>
 <tr>
-<td><code>comment[precursor charge range]</code></td>
+<td><code>comment[precursor max mz]</code></td>
 <td><span class="optional-badge">OPTIONAL</span></td>
-<td>Precursor charge range used for database search</td>
-<td>Numeric range</td>
-<td>1:3, 2:5</td>
+<td>MS method-defined maximum precursor m/z setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000477">PRIDE (PRIDE:0000477)</a></td>
+<td>1600, 2000</td>
+</tr>
+<tr>
+<td><code>comment[precursor min charge]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined minimum precursor charge state setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000472">PRIDE (PRIDE:0000472)</a></td>
+<td>1, 2</td>
+</tr>
+<tr>
+<td><code>comment[precursor max charge]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined maximum precursor charge state setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000473">PRIDE (PRIDE:0000473)</a></td>
+<td>4, 6</td>
+</tr>
+<tr>
+<td><code>comment[min retention time]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>LC method-defined minimum retention time setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000474">PRIDE (PRIDE:0000474)</a></td>
+<td>0, 5</td>
+</tr>
+<tr>
+<td><code>comment[max retention time]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>LC method-defined maximum retention time setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000475">PRIDE (PRIDE:0000475)</a></td>
+<td>120, 90</td>
+</tr>
+<tr>
+<td><code>comment[min ion mobility]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined minimum ion mobility setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000841">PRIDE (PRIDE:0000841)</a></td>
+<td>0.6, 0.7</td>
+</tr>
+<tr>
+<td><code>comment[max ion mobility]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined maximum ion mobility setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000842">PRIDE (PRIDE:0000842)</a></td>
+<td>1.4, 1.6</td>
 </tr>
 </tbody>
 </table>
@@ -154,8 +196,14 @@ ifndef::backend-html5[]
 |comment[precursor mass tolerance] |OPTIONAL |Mass tolerance for precursor ions in database search |Numeric value with unit |10 ppm, 20 ppm
 |comment[fragment mass tolerance] |OPTIONAL |Mass tolerance for fragment ions in database search |Numeric value with unit |0.02 Da, 20 ppm
 |comment[MS2 mass analyzer] |OPTIONAL |Mass analyzer used for MS2 acquisition |PSI-MS (MS:1000443) |NT=orbitrap;AC=MS:1000484
-|comment[precursor mass range] |OPTIONAL |Precursor mass range used for database search |Numeric range in Da |800:2500, 800:5000
-|comment[precursor charge range] |OPTIONAL |Precursor charge range used for database search |Numeric range |1:3, 2:5
+|comment[precursor min mz] |OPTIONAL |MS method-defined minimum precursor m/z setting used to acquire the data |PRIDE (PRIDE:0000476) |350, 400
+|comment[precursor max mz] |OPTIONAL |MS method-defined maximum precursor m/z setting used to acquire the data |PRIDE (PRIDE:0000477) |1600, 2000
+|comment[precursor min charge] |OPTIONAL |MS method-defined minimum precursor charge state setting used to acquire the data |PRIDE (PRIDE:0000472) |1, 2
+|comment[precursor max charge] |OPTIONAL |MS method-defined maximum precursor charge state setting used to acquire the data |PRIDE (PRIDE:0000473) |4, 6
+|comment[min retention time] |OPTIONAL |LC method-defined minimum retention time setting used to acquire the data |PRIDE (PRIDE:0000474) |0, 5
+|comment[max retention time] |OPTIONAL |LC method-defined maximum retention time setting used to acquire the data |PRIDE (PRIDE:0000475) |120, 90
+|comment[min ion mobility] |OPTIONAL |MS method-defined minimum ion mobility setting used to acquire the data |PRIDE (PRIDE:0000841) |0.6, 0.7
+|comment[max ion mobility] |OPTIONAL |MS method-defined maximum ion mobility setting used to acquire the data |PRIDE (PRIDE:0000842) |1.4, 1.6
 |===
 endif::[]
 

--- a/sdrf-proteomics/templates/dia-acquisition/README.adoc
+++ b/sdrf-proteomics/templates/dia-acquisition/README.adoc
@@ -186,6 +186,62 @@ ifdef::backend-html5[]
 <td>Numeric value with unit</td>
 <td>0.02 Da, 20 ppm</td>
 </tr>
+<tr>
+<td><code>comment[precursor min mz]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined minimum precursor m/z setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000476">PRIDE (PRIDE:0000476)</a></td>
+<td>350, 400</td>
+</tr>
+<tr>
+<td><code>comment[precursor max mz]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined maximum precursor m/z setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000477">PRIDE (PRIDE:0000477)</a></td>
+<td>1600, 2000</td>
+</tr>
+<tr>
+<td><code>comment[precursor min charge]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined minimum precursor charge state setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000472">PRIDE (PRIDE:0000472)</a></td>
+<td>1, 2</td>
+</tr>
+<tr>
+<td><code>comment[precursor max charge]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined maximum precursor charge state setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000473">PRIDE (PRIDE:0000473)</a></td>
+<td>4, 6</td>
+</tr>
+<tr>
+<td><code>comment[min retention time]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>LC method-defined minimum retention time setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000474">PRIDE (PRIDE:0000474)</a></td>
+<td>0, 5</td>
+</tr>
+<tr>
+<td><code>comment[max retention time]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>LC method-defined maximum retention time setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000475">PRIDE (PRIDE:0000475)</a></td>
+<td>120, 90</td>
+</tr>
+<tr>
+<td><code>comment[min ion mobility]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined minimum ion mobility setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000841">PRIDE (PRIDE:0000841)</a></td>
+<td>0.6, 0.7</td>
+</tr>
+<tr>
+<td><code>comment[max ion mobility]</code></td>
+<td><span class="optional-badge">OPTIONAL</span></td>
+<td>MS method-defined maximum ion mobility setting used to acquire the data</td>
+<td><a href="https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000842">PRIDE (PRIDE:0000842)</a></td>
+<td>1.4, 1.6</td>
+</tr>
 </tbody>
 </table>
 ++++
@@ -198,6 +254,14 @@ ifndef::backend-html5[]
 
 |comment[precursor mass tolerance] |OPTIONAL |Mass tolerance for precursor ions in database search |Numeric value with unit |10 ppm, 20 ppm
 |comment[fragment mass tolerance] |OPTIONAL |Mass tolerance for fragment ions in database search |Numeric value with unit |0.02 Da, 20 ppm
+|comment[precursor min mz] |OPTIONAL |MS method-defined minimum precursor m/z setting used to acquire the data |PRIDE (PRIDE:0000476) |350, 400
+|comment[precursor max mz] |OPTIONAL |MS method-defined maximum precursor m/z setting used to acquire the data |PRIDE (PRIDE:0000477) |1600, 2000
+|comment[precursor min charge] |OPTIONAL |MS method-defined minimum precursor charge state setting used to acquire the data |PRIDE (PRIDE:0000472) |1, 2
+|comment[precursor max charge] |OPTIONAL |MS method-defined maximum precursor charge state setting used to acquire the data |PRIDE (PRIDE:0000473) |4, 6
+|comment[min retention time] |OPTIONAL |LC method-defined minimum retention time setting used to acquire the data |PRIDE (PRIDE:0000474) |0, 5
+|comment[max retention time] |OPTIONAL |LC method-defined maximum retention time setting used to acquire the data |PRIDE (PRIDE:0000475) |120, 90
+|comment[min ion mobility] |OPTIONAL |MS method-defined minimum ion mobility setting used to acquire the data |PRIDE (PRIDE:0000841) |0.6, 0.7
+|comment[max ion mobility] |OPTIONAL |MS method-defined maximum ion mobility setting used to acquire the data |PRIDE (PRIDE:0000842) |1.4, 1.6
 |===
 endif::[]
 
@@ -381,18 +445,20 @@ NOTE: The `...` column indicates omitted columns (organism part, biological repl
 [[diaPASEF-example]]
 == diaPASEF Example
 
-For ion mobility-enhanced DIA (diaPASEF), additional columns may be relevant:
+For ion mobility-enhanced DIA (diaPASEF), the following columns capture the ion mobility acquisition window:
 
 |===
-|Column Name |Description |Example Values
+|Column Name |Description |PRIDE CV |Example Values
 
-|comment[ion mobility]
-|Ion mobility separation used
-|TIMS, FAIMS, not applicable
+|comment[min ion mobility]
+|MS method-defined minimum ion mobility setting used to acquire the data
+|PRIDE:0000841
+|0.6
 
-|comment[1/K0 range]
-|Ion mobility range
-|0.6-1.6 1/K0
+|comment[max ion mobility]
+|MS method-defined maximum ion mobility setting used to acquire the data
+|PRIDE:0000842
+|1.6
 |===
 
 [[best-practices]]


### PR DESCRIPTION
## Summary
- Replaces the previous colon-delimited `comment[precursor mass range]` and `comment[precursor charge range]` columns with individual min/max columns, and adds retention time and ion mobility min/max columns
- All columns use existing PRIDE ontology accessions and apply to both DDA and DIA templates
- Ion mobility terms (PRIDE:0000841, PRIDE:0000842) reference the new ontology entries from https://github.com/PRIDE-Archive/pride-ontology/pull/163

### New optional columns

| Column | PRIDE CV | Description |
|--------|----------|-------------|
| `comment[precursor min mz]` | PRIDE:0000476 | MS method-defined minimum precursor m/z setting used to acquire the data |
| `comment[precursor max mz]` | PRIDE:0000477 | MS method-defined maximum precursor m/z setting used to acquire the data |
| `comment[precursor min charge]` | PRIDE:0000472 | MS method-defined minimum precursor charge state setting used to acquire the data |
| `comment[precursor max charge]` | PRIDE:0000473 | MS method-defined maximum precursor charge state setting used to acquire the data |
| `comment[min retention time]` | PRIDE:0000474 | LC method-defined minimum retention time setting used to acquire the data |
| `comment[max retention time]` | PRIDE:0000475 | LC method-defined maximum retention time setting used to acquire the data |
| `comment[min ion mobility]` | PRIDE:0000841 | MS method-defined minimum ion mobility setting used to acquire the data |
| `comment[max ion mobility]` | PRIDE:0000842 | MS method-defined maximum ion mobility setting used to acquire the data |

### Files changed
- `sdrf-proteomics/metadata-guidelines/sdrf-terms.tsv` — column definitions
- `sdrf-proteomics/templates/dda-acquisition/README.adoc` — DDA template optional columns
- `sdrf-proteomics/templates/dia-acquisition/README.adoc` — DIA template optional columns + updated diaPASEF example

Closes #774 (point 3)