### PR TITLE
Site: read SDRF Explorer index from sdrf-annotated-datasets at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ CLAUDE.md
 # Local files for developers are in folder in local-info
 local-info/
 **/__pycache__/
+
+# Shallow clone of sdrf-annotated-datasets (provisioned by scripts/build-docs.sh)
+/vendor/

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -184,6 +184,29 @@ echo "Updating index template section..."
 python3 scripts/build_index_templates.py \
     sdrf-proteomics/sdrf-templates "$OUTPUT_DIR/index.html"
 
+# Provision the external sdrf-annotated-datasets repository so the index
+# script can read the SDRF files. Honour SDRF_DATASETS_DIR if the caller
+# already provided one (local dev with an existing checkout); otherwise
+# shallow-clone the default branch into vendor/.
+SDRF_DATASETS_REPO="${SDRF_DATASETS_REPO:-bigbio/sdrf-annotated-datasets}"
+SDRF_DATASETS_BRANCH="${SDRF_DATASETS_BRANCH:-main}"
+if [ -z "${SDRF_DATASETS_DIR:-}" ]; then
+    VENDOR_DIR="$REPO_ROOT/vendor/sdrf-annotated-datasets"
+    if [ ! -d "$VENDOR_DIR/.git" ]; then
+        echo "Cloning $SDRF_DATASETS_REPO@$SDRF_DATASETS_BRANCH into $VENDOR_DIR ..."
+        mkdir -p "$(dirname "$VENDOR_DIR")"
+        git clone --depth 1 --branch "$SDRF_DATASETS_BRANCH" \
+            "https://github.com/$SDRF_DATASETS_REPO.git" "$VENDOR_DIR"
+    else
+        echo "Updating existing clone at $VENDOR_DIR ..."
+        git -C "$VENDOR_DIR" fetch --depth 1 origin "$SDRF_DATASETS_BRANCH"
+        git -C "$VENDOR_DIR" reset --hard "origin/$SDRF_DATASETS_BRANCH"
+    fi
+    SDRF_DATASETS_DIR="$VENDOR_DIR/datasets"
+fi
+export SDRF_DATASETS_DIR SDRF_DATASETS_REPO SDRF_DATASETS_BRANCH
+echo "Using SDRF datasets from: $SDRF_DATASETS_DIR"
+
 # Build SDRF Explorer index
 echo "Building SDRF Explorer index..."
 python3 site/build-sdrf-index.py

--- a/site/build-sdrf-index.py
+++ b/site/build-sdrf-index.py
@@ -95,12 +95,27 @@ def parse_ontology_term(value):
 
 def main():
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    annotated_dir = os.path.join(base_dir, 'annotated-projects')
     datasets_prefix = 'datasets'
-    datasets_repo = 'bigbio/sdrf-annotated-datasets'
-    datasets_branch = 'dev'
+    datasets_repo = os.environ.get('SDRF_DATASETS_REPO', 'bigbio/sdrf-annotated-datasets')
+    datasets_branch = os.environ.get('SDRF_DATASETS_BRANCH', 'main')
+
+    # Annotated SDRFs live in the external sdrf-annotated-datasets repository.
+    # SDRF_DATASETS_DIR must point at its datasets/ folder (either a local
+    # checkout or a shallow clone produced by scripts/build-docs.sh / CI).
+    datasets_dir = os.environ.get('SDRF_DATASETS_DIR')
+    if not datasets_dir:
+        raise SystemExit(
+            "SDRF_DATASETS_DIR is not set. Point it at a checkout of "
+            f"https://github.com/{datasets_repo} (the datasets/ folder). "
+            "scripts/build-docs.sh provisions this automatically."
+        )
+    if not os.path.isdir(datasets_dir):
+        raise SystemExit(
+            f"SDRF_DATASETS_DIR={datasets_dir!r} does not exist or is not a directory."
+        )
+
     # Find all SDRF files
-    sdrf_files = glob.glob(os.path.join(annotated_dir, '**', '*.sdrf.tsv'), recursive=True)
+    sdrf_files = glob.glob(os.path.join(datasets_dir, '**', '*.sdrf.tsv'), recursive=True)
 
     # Statistics counters
     total_samples = 0
@@ -122,12 +137,11 @@ def main():
         if '/.' in filepath:
             continue
 
-        rel_path = os.path.relpath(filepath, base_dir)
-
-        # Extract project ID from path
-        parts = rel_path.split(os.sep)
+        # Extract project ID from the path inside the datasets/ tree
+        rel_in_datasets = os.path.relpath(filepath, datasets_dir)
+        parts = rel_in_datasets.split(os.sep)
         if len(parts) >= 2:
-            project_id = parts[1]
+            project_id = parts[0]
         else:
             project_id = os.path.basename(filepath).replace('.sdrf.tsv', '')
 

--- a/site/sdrf-data.json
+++ b/site/sdrf-data.json
@@ -1,10 +1,10 @@
 {
   "statistics": {
-    "total_datasets": 298,
-    "total_samples": 80289,
-    "generated_at": "2026-04-17T16:17:53.486665Z",
+    "total_datasets": 297,
+    "total_samples": 76039,
+    "generated_at": "2026-04-19T06:43:46.990076Z",
     "organisms": {
-      "Homo sapiens": 51421,
+      "Homo sapiens": 47171,
       "homo sapiens": 10167,
       "Mus musculus": 4460,
       "Homo Sapiens": 3873,
@@ -36,7 +36,6 @@
       "breast": 6237,
       "lung": 5356,
       "blood plasma": 4903,
-      "Breast": 3997,
       "ovary": 3172,
       "bone marrow": 2411,
       "Muscle": 2316,
@@ -72,6 +71,7 @@
       "flower bud": 240,
       "medial frontal gyrus": 240,
       "Caco-2 cells": 240,
+      "Breast": 222,
       "root": 220,
       "Blood serum": 213,
       "Colon": 211,
@@ -86,7 +86,6 @@
     },
     "diseases": {
       "squamous cell lung cancer": 4292,
-      "Breast Invasive Carcinoma": 3775,
       "metastatic cutaneous melanoma": 3600,
       "breast cancer": 2355,
       "ovarian high grade serous adenocarcinoma": 2231,
@@ -114,7 +113,6 @@
       "colorectal adenocarcinoma": 528,
       "non-small cell lung cancer": 516,
       "colon cancer": 478,
-      "Other": 475,
       "malignant melanoma": 432,
       "Rectal Adenocarcinoma": 390,
       "Alzheimer's disease": 361,
@@ -134,13 +132,14 @@
       "Prostate adenocarcinoma": 172,
       "lung adenocarcinoma": 169,
       "hepatocellular carcinoma (HCC)": 160,
-      "colon and rectal tumors": 150
+      "colon and rectal tumors": 150,
+      "Breast cancer": 141,
+      "Triple-negative breast cancer": 141
     },
     "cell_types": {
       "epithelial cell": 5207,
       "epithelial": 4805,
       "malignant cell": 3600,
-      "Primary Tumor": 3325,
       "lymphoblast": 2298,
       "schizonts": 2032,
       "cardiac": 1803,
@@ -148,7 +147,6 @@
       "Prokaryotic cell": 1535,
       "schizont": 844,
       "melanoma cell": 764,
-      "Solid Tissue Normal": 450,
       "Cancerous cell": 276,
       "platelet": 270,
       "Epithelial": 258,
@@ -186,14 +184,16 @@
       "kidney": 40,
       "lung": 40,
       "brown adipose tissue": 39,
-      "liver": 36
+      "liver": 36,
+      "testis": 36,
+      "myoblast": 36
     },
     "instruments": {
       "Q Exactive": 18091,
-      "Orbitrap Fusion Lumos": 12286,
       "Q Exactive Plus": 10628,
       "LTQ Orbitrap Velos": 8703,
       "Q Exactive HF": 8662,
+      "Orbitrap Fusion Lumos": 8036,
       "Orbitrap Fusion": 4610,
       "orbitrap": 4359,
       "Orbitrap Elite": 3998,
@@ -224,17 +224,17 @@
     "labels": {
       "label free sample": 34037,
       "Label free": 4395,
-      "TMT126": 3702,
-      "TMT131": 3111,
+      "TMT126": 3277,
       "SILAC heavy": 2726,
-      "TMT127N": 2372,
-      "TMT128N": 2372,
-      "TMT128C": 2372,
-      "TMT129N": 2372,
-      "TMT129C": 2372,
-      "TMT130N": 2372,
-      "TMT130C": 2372,
-      "TMT127C": 2371,
+      "TMT131": 2686,
+      "TMT127N": 1947,
+      "TMT128N": 1947,
+      "TMT128C": 1947,
+      "TMT129N": 1947,
+      "TMT129C": 1947,
+      "TMT130N": 1947,
+      "TMT130C": 1947,
+      "TMT127C": 1946,
       "TMT127": 1595,
       "TMT128": 1595,
       "TMT129": 1595,
@@ -244,7 +244,7 @@
       "SILAC light": 929
     },
     "acquisition_methods": {
-      "Data-dependent acquisition": 78518,
+      "Data-dependent acquisition": 74268,
       "data-dependent acquisition": 898,
       "Data-independent acquisition": 662,
       "selected reaction monitoring": 205,
@@ -283,7 +283,7 @@
       "Ubiquitination": 78
     },
     "cleavage_agents": {
-      "Trypsin": 60748,
+      "Trypsin": 56498,
       "Lys-C": 10184,
       "Trypsin/P": 6452,
       "unspecific cleavage": 1248,
@@ -301,18 +301,18 @@
       "no cleavage": 5
     },
     "experiment_types": {
-      "DDA": 290,
+      "DDA": 289,
       "SRM/MRM": 3,
       "DIA": 5
     },
     "label_types": {
       "Label-free": 229,
-      "TMT": 36,
+      "TMT": 35,
       "SILAC": 23,
       "iTRAQ": 10
     },
     "templates": {
-      "unknown": 298
+      "unknown": 297
     }
   },
   "datasets": [
@@ -321,8 +321,8 @@
       "file": "COMBINEDPX0000001.sdrf.tsv",
       "filename": "COMBINEDPX0000001.sdrf.tsv",
       "path": "datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
       "num_samples": 35,
       "num_columns": 32,
       "organisms": [
@@ -350,13 +350,13 @@
       "file": "MSV000078494.sdrf.tsv",
       "filename": "MSV000078494.sdrf.tsv",
       "path": "datasets/MSV000078494/MSV000078494.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000078494/MSV000078494.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000078494/MSV000078494.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000078494/MSV000078494.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000078494/MSV000078494.sdrf.tsv",
       "num_samples": 96,
       "num_columns": 35,
       "organisms": [
-        "homo sapiens",
-        "mus musculus"
+        "mus musculus",
+        "homo sapiens"
       ],
       "diseases": [
         "melanoma"
@@ -377,8 +377,8 @@
       "file": "MSV000078535.sdrf.tsv",
       "filename": "MSV000078535.sdrf.tsv",
       "path": "datasets/MSV000078535/MSV000078535.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000078535/MSV000078535.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000078535/MSV000078535.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000078535/MSV000078535.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000078535/MSV000078535.sdrf.tsv",
       "num_samples": 44,
       "num_columns": 37,
       "organisms": [
@@ -403,8 +403,8 @@
       "file": "MSV000078555.sdrf.tsv",
       "filename": "MSV000078555.sdrf.tsv",
       "path": "datasets/MSV000078555/MSV000078555.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000078555/MSV000078555.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000078555/MSV000078555.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000078555/MSV000078555.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000078555/MSV000078555.sdrf.tsv",
       "num_samples": 176,
       "num_columns": 37,
       "organisms": [
@@ -430,20 +430,20 @@
       "file": "MSV000080451.sdrf.tsv",
       "filename": "MSV000080451.sdrf.tsv",
       "path": "datasets/MSV000080451/MSV000080451.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000080451/MSV000080451.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000080451/MSV000080451.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000080451/MSV000080451.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000080451/MSV000080451.sdrf.tsv",
       "num_samples": 71,
       "num_columns": 33,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "multiple myeloma",
-        "monoclonal gammopathy"
+        "monoclonal gammopathy",
+        "multiple myeloma"
       ],
       "instruments": [
-        "Orbitrap Elite",
-        "LTQ Orbitrap XL"
+        "LTQ Orbitrap XL",
+        "Orbitrap Elite"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -458,8 +458,8 @@
       "file": "MSV000086206.sdrf.tsv",
       "filename": "MSV000086206.sdrf.tsv",
       "path": "datasets/MSV000086206/MSV000086206.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000086206/MSV000086206.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000086206/MSV000086206.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000086206/MSV000086206.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000086206/MSV000086206.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 21,
       "organisms": [
@@ -482,8 +482,8 @@
       "file": "PMID21183079.sdrf.tsv",
       "filename": "PMID21183079.sdrf.tsv",
       "path": "datasets/PMID21183079/PMID21183079.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID21183079/PMID21183079.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID21183079/PMID21183079.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID21183079/PMID21183079.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID21183079/PMID21183079.sdrf.tsv",
       "num_samples": 347,
       "num_columns": 31,
       "organisms": [
@@ -506,17 +506,17 @@
       "file": "PMID25043054.sdrf.tsv",
       "filename": "PMID25043054.sdrf.tsv",
       "path": "datasets/PMID25043054/PMID25043054.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID25043054/PMID25043054.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID25043054/PMID25043054.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID25043054/PMID25043054.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID25043054/PMID25043054.sdrf.tsv",
       "num_samples": 1425,
       "num_columns": 41,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
+        "Colon Adenocarcinoma",
         "Colon Mucinous Adenocarcinoma",
         "Rectal Adenocarcinoma",
-        "Colon Adenocarcinoma",
         "Rectal Mucinous Adenocarcinoma"
       ],
       "instruments": [
@@ -535,8 +535,8 @@
       "file": "PMID28625833.sdrf.tsv",
       "filename": "PMID28625833.sdrf.tsv",
       "path": "datasets/PMID28625833/PMID28625833.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID28625833/PMID28625833.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID28625833/PMID28625833.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID28625833/PMID28625833.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID28625833/PMID28625833.sdrf.tsv",
       "num_samples": 660,
       "num_columns": 32,
       "organisms": [
@@ -561,8 +561,8 @@
       "file": "PMID31975593.sdrf.tsv",
       "filename": "PMID31975593.sdrf.tsv",
       "path": "datasets/PMID31975593/PMID31975593.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID31975593/PMID31975593.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID31975593/PMID31975593.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID31975593/PMID31975593.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID31975593/PMID31975593.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 33,
       "organisms": [
@@ -587,8 +587,8 @@
       "file": "PMID33086064.sdrf.tsv",
       "filename": "PMID33086064.sdrf.tsv",
       "path": "datasets/PMID33086064/PMID33086064.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID33086064/PMID33086064.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID33086064/PMID33086064.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID33086064/PMID33086064.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID33086064/PMID33086064.sdrf.tsv",
       "num_samples": 3120,
       "num_columns": 39,
       "organisms": [
@@ -610,39 +610,12 @@
       "version": "unknown"
     },
     {
-      "id": "PMID33212010",
-      "file": "PMID33212010.sdrf.tsv",
-      "filename": "PMID33212010.sdrf.tsv",
-      "path": "datasets/PMID33212010/PMID33212010.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID33212010/PMID33212010.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID33212010/PMID33212010.sdrf.tsv",
-      "num_samples": 4250,
-      "num_columns": 37,
-      "organisms": [
-        "Homo sapiens"
-      ],
-      "diseases": [
-        "Breast Invasive Carcinoma",
-        "Other"
-      ],
-      "instruments": [
-        "Orbitrap Fusion Lumos"
-      ],
-      "acquisition_methods": [
-        "Data-dependent acquisition"
-      ],
-      "experiment_type": "DDA",
-      "label_type": "TMT",
-      "template": "unknown",
-      "version": "unknown"
-    },
-    {
       "id": "PXD000070",
       "file": "PXD000070.sdrf.tsv",
       "filename": "PXD000070.sdrf.tsv",
       "path": "datasets/PXD000070/PXD000070.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000070/PXD000070.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000070/PXD000070.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000070/PXD000070.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000070/PXD000070.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 31,
       "organisms": [
@@ -665,8 +638,8 @@
       "file": "PXD000228.sdrf.tsv",
       "filename": "PXD000228.sdrf.tsv",
       "path": "datasets/PXD000228/PXD000228.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000228/PXD000228.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000228/PXD000228.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000228/PXD000228.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000228/PXD000228.sdrf.tsv",
       "num_samples": 270,
       "num_columns": 35,
       "organisms": [
@@ -689,8 +662,8 @@
       "file": "PXD000288.sdrf.tsv",
       "filename": "PXD000288.sdrf.tsv",
       "path": "datasets/PXD000288/PXD000288.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000288/PXD000288.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000288/PXD000288.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000288/PXD000288.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000288/PXD000288.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 36,
       "organisms": [
@@ -713,8 +686,8 @@
       "file": "PXD000312.sdrf.tsv",
       "filename": "PXD000312.sdrf.tsv",
       "path": "datasets/PXD000312/PXD000312.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000312/PXD000312.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000312/PXD000312.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000312/PXD000312.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000312/PXD000312.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 29,
       "organisms": [
@@ -739,8 +712,8 @@
       "file": "PXD000396.sdrf.tsv",
       "filename": "PXD000396.sdrf.tsv",
       "path": "datasets/PXD000396/PXD000396.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000396/PXD000396.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000396/PXD000396.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000396/PXD000396.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000396/PXD000396.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 35,
       "organisms": [
@@ -765,8 +738,8 @@
       "file": "PXD000498.sdrf.tsv",
       "filename": "PXD000498.sdrf.tsv",
       "path": "datasets/PXD000498/PXD000498.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000498/PXD000498.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000498/PXD000498.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000498/PXD000498.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000498/PXD000498.sdrf.tsv",
       "num_samples": 84,
       "num_columns": 37,
       "organisms": [
@@ -789,8 +762,8 @@
       "file": "PXD000527.sdrf.tsv",
       "filename": "PXD000527.sdrf.tsv",
       "path": "datasets/PXD000527/PXD000527.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000527/PXD000527.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000527/PXD000527.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000527/PXD000527.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000527/PXD000527.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 26,
       "organisms": [
@@ -813,8 +786,8 @@
       "file": "PXD000534.sdrf.tsv",
       "filename": "PXD000534.sdrf.tsv",
       "path": "datasets/PXD000534/PXD000534.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000534/PXD000534.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000534/PXD000534.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000534/PXD000534.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000534/PXD000534.sdrf.tsv",
       "num_samples": 16,
       "num_columns": 30,
       "organisms": [
@@ -839,17 +812,17 @@
       "file": "PXD000547.sdrf.tsv",
       "filename": "PXD000547.sdrf.tsv",
       "path": "datasets/PXD000547/PXD000547.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000547/PXD000547.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000547/PXD000547.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000547/PXD000547.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000547/PXD000547.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 34,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "lung embolism",
         "cardiopulmonary insufficiency",
-        "heart infarction"
+        "heart infarction",
+        "lung embolism"
       ],
       "instruments": [
         "LTQ Orbitrap XL"
@@ -867,17 +840,17 @@
       "file": "PXD000548.sdrf.tsv",
       "filename": "PXD000548.sdrf.tsv",
       "path": "datasets/PXD000548/PXD000548.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000548/PXD000548.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000548/PXD000548.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000548/PXD000548.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000548/PXD000548.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 31,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "lung embolism",
         "cardiopulmonary insufficiency",
-        "heart infarction"
+        "heart infarction",
+        "lung embolism"
       ],
       "instruments": [
         "LTQ Orbitrap XL"
@@ -895,8 +868,8 @@
       "file": "PXD000561.sdrf.tsv",
       "filename": "PXD000561.sdrf.tsv",
       "path": "datasets/PXD000561/PXD000561.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000561/PXD000561.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000561/PXD000561.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000561/PXD000561.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000561/PXD000561.sdrf.tsv",
       "num_samples": 2212,
       "num_columns": 36,
       "organisms": [
@@ -920,8 +893,8 @@
       "file": "PXD000612.sdrf.tsv",
       "filename": "PXD000612.sdrf.tsv",
       "path": "datasets/PXD000612/PXD000612.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000612/PXD000612.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000612/PXD000612.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000612/PXD000612.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000612/PXD000612.sdrf.tsv",
       "num_samples": 273,
       "num_columns": 37,
       "organisms": [
@@ -946,8 +919,8 @@
       "file": "PXD000651.sdrf.tsv",
       "filename": "PXD000651.sdrf.tsv",
       "path": "datasets/PXD000651/PXD000651.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000651/PXD000651.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000651/PXD000651.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000651/PXD000651.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000651/PXD000651.sdrf.tsv",
       "num_samples": 37,
       "num_columns": 32,
       "organisms": [
@@ -972,8 +945,8 @@
       "file": "PXD000652.sdrf.tsv",
       "filename": "PXD000652.sdrf.tsv",
       "path": "datasets/PXD000652/PXD000652.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000652/PXD000652.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000652/PXD000652.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000652/PXD000652.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000652/PXD000652.sdrf.tsv",
       "num_samples": 46,
       "num_columns": 32,
       "organisms": [
@@ -998,8 +971,8 @@
       "file": "PXD000759.sdrf.tsv",
       "filename": "PXD000759.sdrf.tsv",
       "path": "datasets/PXD000759/PXD000759.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000759/PXD000759.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000759/PXD000759.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000759/PXD000759.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000759/PXD000759.sdrf.tsv",
       "num_samples": 336,
       "num_columns": 33,
       "organisms": [
@@ -1024,8 +997,8 @@
       "file": "PXD000790.sdrf.tsv",
       "filename": "PXD000790.sdrf.tsv",
       "path": "datasets/PXD000790/PXD000790.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000790/PXD000790.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000790/PXD000790.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000790/PXD000790.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000790/PXD000790.sdrf.tsv",
       "num_samples": 1,
       "num_columns": 30,
       "organisms": [
@@ -1048,8 +1021,8 @@
       "file": "PXD000792.sdrf.tsv",
       "filename": "PXD000792.sdrf.tsv",
       "path": "datasets/PXD000792/PXD000792.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000792/PXD000792.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000792/PXD000792.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000792/PXD000792.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000792/PXD000792.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 23,
       "organisms": [
@@ -1072,8 +1045,8 @@
       "file": "PXD000793.sdrf.tsv",
       "filename": "PXD000793.sdrf.tsv",
       "path": "datasets/PXD000793/PXD000793.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000793/PXD000793.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000793/PXD000793.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000793/PXD000793.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000793/PXD000793.sdrf.tsv",
       "num_samples": 116,
       "num_columns": 28,
       "organisms": [
@@ -1096,8 +1069,8 @@
       "file": "PXD000815.sdrf.tsv",
       "filename": "PXD000815.sdrf.tsv",
       "path": "datasets/PXD000815/PXD000815.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000815/PXD000815.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000815/PXD000815.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000815/PXD000815.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000815/PXD000815.sdrf.tsv",
       "num_samples": 454,
       "num_columns": 35,
       "organisms": [
@@ -1122,8 +1095,8 @@
       "file": "PXD000857.sdrf.tsv",
       "filename": "PXD000857.sdrf.tsv",
       "path": "datasets/PXD000857/PXD000857.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000857/PXD000857.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000857/PXD000857.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000857/PXD000857.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000857/PXD000857.sdrf.tsv",
       "num_samples": 1,
       "num_columns": 26,
       "organisms": [
@@ -1146,8 +1119,8 @@
       "file": "PXD000895.sdrf.tsv",
       "filename": "PXD000895.sdrf.tsv",
       "path": "datasets/PXD000895/PXD000895.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000895/PXD000895.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000895/PXD000895.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000895/PXD000895.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000895/PXD000895.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 29,
       "organisms": [
@@ -1172,8 +1145,8 @@
       "file": "PXD000923.sdrf.tsv",
       "filename": "PXD000923.sdrf.tsv",
       "path": "datasets/PXD000923/PXD000923.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000923/PXD000923.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000923/PXD000923.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000923/PXD000923.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000923/PXD000923.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 27,
       "organisms": [
@@ -1196,8 +1169,8 @@
       "file": "PXD000999.sdrf.tsv",
       "filename": "PXD000999.sdrf.tsv",
       "path": "datasets/PXD000999/PXD000999.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000999/PXD000999.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000999/PXD000999.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000999/PXD000999.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000999/PXD000999.sdrf.tsv",
       "num_samples": 7,
       "num_columns": 34,
       "organisms": [
@@ -1222,8 +1195,8 @@
       "file": "PXD001061.sdrf.tsv",
       "filename": "PXD001061.sdrf.tsv",
       "path": "datasets/PXD001061/PXD001061.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001061/PXD001061.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001061/PXD001061.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001061/PXD001061.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001061/PXD001061.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 38,
       "organisms": [
@@ -1248,8 +1221,8 @@
       "file": "PXD001168.sdrf.tsv",
       "filename": "PXD001168.sdrf.tsv",
       "path": "datasets/PXD001168/PXD001168.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001168/PXD001168.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001168/PXD001168.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001168/PXD001168.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001168/PXD001168.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 26,
       "organisms": [
@@ -1272,8 +1245,8 @@
       "file": "PXD001224.sdrf.tsv",
       "filename": "PXD001224.sdrf.tsv",
       "path": "datasets/PXD001224/PXD001224.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001224/PXD001224.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001224/PXD001224.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001224/PXD001224.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001224/PXD001224.sdrf.tsv",
       "num_samples": 108,
       "num_columns": 35,
       "organisms": [
@@ -1296,8 +1269,8 @@
       "file": "PXD001325.sdrf.tsv",
       "filename": "PXD001325.sdrf.tsv",
       "path": "datasets/PXD001325/PXD001325.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001325/PXD001325.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001325/PXD001325.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001325/PXD001325.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001325/PXD001325.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 31,
       "organisms": [
@@ -1322,8 +1295,8 @@
       "file": "PXD001281.sdrf.tsv",
       "filename": "PXD001281.sdrf.tsv",
       "path": "datasets/PXD001381/PXD001281.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001381/PXD001281.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001381/PXD001281.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001381/PXD001281.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001381/PXD001281.sdrf.tsv",
       "num_samples": 84,
       "num_columns": 18,
       "organisms": [
@@ -1348,8 +1321,8 @@
       "file": "PXD001404.sdrf.tsv",
       "filename": "PXD001404.sdrf.tsv",
       "path": "datasets/PXD001404/PXD001404.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001404/PXD001404.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001404/PXD001404.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001404/PXD001404.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001404/PXD001404.sdrf.tsv",
       "num_samples": 154,
       "num_columns": 31,
       "organisms": [
@@ -1372,8 +1345,8 @@
       "file": "PXD001468.sdrf.tsv",
       "filename": "PXD001468.sdrf.tsv",
       "path": "datasets/PXD001468/PXD001468.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001468/PXD001468.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001468/PXD001468.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001468/PXD001468.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001468/PXD001468.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 39,
       "organisms": [
@@ -1396,8 +1369,8 @@
       "file": "PXD001474.sdrf.tsv",
       "filename": "PXD001474.sdrf.tsv",
       "path": "datasets/PXD001474/PXD001474.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001474/PXD001474.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001474/PXD001474.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001474/PXD001474.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001474/PXD001474.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 30,
       "organisms": [
@@ -1422,8 +1395,8 @@
       "file": "PXD001487.sdrf.tsv",
       "filename": "PXD001487.sdrf.tsv",
       "path": "datasets/PXD001487/PXD001487.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001487/PXD001487.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001487/PXD001487.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001487/PXD001487.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001487/PXD001487.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 35,
       "organisms": [
@@ -1448,8 +1421,8 @@
       "file": "PXD001558.sdrf.tsv",
       "filename": "PXD001558.sdrf.tsv",
       "path": "datasets/PXD001558/PXD001558.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001558/PXD001558.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001558/PXD001558.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001558/PXD001558.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001558/PXD001558.sdrf.tsv",
       "num_samples": 123,
       "num_columns": 21,
       "organisms": [
@@ -1474,8 +1447,8 @@
       "file": "PXD001684.sdrf.tsv",
       "filename": "PXD001684.sdrf.tsv",
       "path": "datasets/PXD001684/PXD001684.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001684/PXD001684.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001684/PXD001684.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001684/PXD001684.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001684/PXD001684.sdrf.tsv",
       "num_samples": 71,
       "num_columns": 31,
       "organisms": [
@@ -1498,8 +1471,8 @@
       "file": "PXD001725.sdrf.tsv",
       "filename": "PXD001725.sdrf.tsv",
       "path": "datasets/PXD001725/PXD001725.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001725/PXD001725.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001725/PXD001725.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001725/PXD001725.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001725/PXD001725.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 31,
       "organisms": [
@@ -1524,8 +1497,8 @@
       "file": "PXD001736.sdrf.tsv",
       "filename": "PXD001736.sdrf.tsv",
       "path": "datasets/PXD001736/PXD001736.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001736/PXD001736.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001736/PXD001736.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001736/PXD001736.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001736/PXD001736.sdrf.tsv",
       "num_samples": 84,
       "num_columns": 37,
       "organisms": [
@@ -1550,8 +1523,8 @@
       "file": "PXD001774.sdrf.tsv",
       "filename": "PXD001774.sdrf.tsv",
       "path": "datasets/PXD001774/PXD001774.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001774/PXD001774.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001774/PXD001774.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001774/PXD001774.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001774/PXD001774.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 27,
       "organisms": [
@@ -1574,8 +1547,8 @@
       "file": "PXD001819.sdrf.tsv",
       "filename": "PXD001819.sdrf.tsv",
       "path": "datasets/PXD001819/PXD001819.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001819/PXD001819.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001819/PXD001819.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001819/PXD001819.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001819/PXD001819.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 27,
       "organisms": [
@@ -1598,8 +1571,8 @@
       "file": "PXD002029.sdrf.tsv",
       "filename": "PXD002029.sdrf.tsv",
       "path": "datasets/PXD002029/PXD002029.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002029/PXD002029.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002029/PXD002029.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002029/PXD002029.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002029/PXD002029.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 34,
       "organisms": [
@@ -1624,8 +1597,8 @@
       "file": "PXD002049.sdrf.tsv",
       "filename": "PXD002049.sdrf.tsv",
       "path": "datasets/PXD002049/PXD002049.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002049/PXD002049.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002049/PXD002049.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002049/PXD002049.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002049/PXD002049.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 33,
       "organisms": [
@@ -1650,8 +1623,8 @@
       "file": "PXD002080.sdrf.tsv",
       "filename": "PXD002080.sdrf.tsv",
       "path": "datasets/PXD002080/PXD002080.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002080/PXD002080.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002080/PXD002080.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002080/PXD002080.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002080/PXD002080.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 30,
       "organisms": [
@@ -1676,8 +1649,8 @@
       "file": "PXD002081.sdrf.tsv",
       "filename": "PXD002081.sdrf.tsv",
       "path": "datasets/PXD002081/PXD002081.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002081/PXD002081.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002081/PXD002081.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002081/PXD002081.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002081/PXD002081.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 30,
       "organisms": [
@@ -1702,8 +1675,8 @@
       "file": "PXD002082.sdrf.tsv",
       "filename": "PXD002082.sdrf.tsv",
       "path": "datasets/PXD002082/PXD002082.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002082/PXD002082.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002082/PXD002082.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002082/PXD002082.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002082/PXD002082.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 31,
       "organisms": [
@@ -1728,8 +1701,8 @@
       "file": "PXD002084.sdrf.tsv",
       "filename": "PXD002084.sdrf.tsv",
       "path": "datasets/PXD002084/PXD002084.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002084/PXD002084.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002084/PXD002084.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002084/PXD002084.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002084/PXD002084.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 30,
       "organisms": [
@@ -1754,16 +1727,16 @@
       "file": "PXD002086.sdrf.tsv",
       "filename": "PXD002086.sdrf.tsv",
       "path": "datasets/PXD002086/PXD002086.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002086/PXD002086.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002086/PXD002086.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002086/PXD002086.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002086/PXD002086.sdrf.tsv",
       "num_samples": 153,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "Rectum adenocarcinoma",
-        "Colon adenocarcinoma"
+        "Colon adenocarcinoma",
+        "Rectum adenocarcinoma"
       ],
       "instruments": [
         "LTQ Orbitrap Velos"
@@ -1781,8 +1754,8 @@
       "file": "PXD002087.sdrf.tsv",
       "filename": "PXD002087.sdrf.tsv",
       "path": "datasets/PXD002087/PXD002087.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002087/PXD002087.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002087/PXD002087.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002087/PXD002087.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002087/PXD002087.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 30,
       "organisms": [
@@ -1807,8 +1780,8 @@
       "file": "PXD002088.sdrf.tsv",
       "filename": "PXD002088.sdrf.tsv",
       "path": "datasets/PXD002088/PXD002088.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002088/PXD002088.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002088/PXD002088.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002088/PXD002088.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002088/PXD002088.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 28,
       "organisms": [
@@ -1834,8 +1807,8 @@
       "file": "PXD002171.sdrf.tsv",
       "filename": "PXD002171.sdrf.tsv",
       "path": "datasets/PXD002171/PXD002171.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002171/PXD002171.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002171/PXD002171.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002171/PXD002171.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002171/PXD002171.sdrf.tsv",
       "num_samples": 38,
       "num_columns": 35,
       "organisms": [
@@ -1860,19 +1833,19 @@
       "file": "PXD002192.sdrf.tsv",
       "filename": "PXD002192.sdrf.tsv",
       "path": "datasets/PXD002192/PXD002192.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002192/PXD002192.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002192/PXD002192.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002192/PXD002192.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002192/PXD002192.sdrf.tsv",
       "num_samples": 276,
       "num_columns": 35,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "Breast Adenocarcinoma",
         "Breast Cancer",
-        "Mlignant Melanoma",
         "Glioblastoma",
-        "Pancreatic Carcinoma"
+        "Pancreatic Carcinoma",
+        "Breast Adenocarcinoma",
+        "Mlignant Melanoma"
       ],
       "instruments": [
         "LTQ Orbitrap Velos"
@@ -1890,8 +1863,8 @@
       "file": "PXD002222.sdrf.tsv",
       "filename": "PXD002222.sdrf.tsv",
       "path": "datasets/PXD002222/PXD002222.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002222/PXD002222.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002222/PXD002222.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002222/PXD002222.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002222/PXD002222.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 28,
       "organisms": [
@@ -1916,8 +1889,8 @@
       "file": "PXD002255.sdrf.tsv",
       "filename": "PXD002255.sdrf.tsv",
       "path": "datasets/PXD002255/PXD002255.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002255/PXD002255.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002255/PXD002255.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002255/PXD002255.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002255/PXD002255.sdrf.tsv",
       "num_samples": 428,
       "num_columns": 35,
       "organisms": [
@@ -1942,8 +1915,8 @@
       "file": "PXD002266.sdrf.tsv",
       "filename": "PXD002266.sdrf.tsv",
       "path": "datasets/PXD002266/PXD002266.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002266/PXD002266.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002266/PXD002266.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002266/PXD002266.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002266/PXD002266.sdrf.tsv",
       "num_samples": 216,
       "num_columns": 28,
       "organisms": [
@@ -1966,8 +1939,8 @@
       "file": "PXD002370.sdrf.tsv",
       "filename": "PXD002370.sdrf.tsv",
       "path": "datasets/PXD002370/PXD002370.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002370/PXD002370.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002370/PXD002370.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002370/PXD002370.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002370/PXD002370.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 32,
       "organisms": [
@@ -1990,24 +1963,24 @@
       "file": "PXD002395.sdrf.tsv",
       "filename": "PXD002395.sdrf.tsv",
       "path": "datasets/PXD002395/PXD002395.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002395/PXD002395.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002395/PXD002395.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002395/PXD002395.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002395/PXD002395.sdrf.tsv",
       "num_samples": 198,
       "num_columns": 36,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
+        "Colon carcinoma",
+        "Human papillomavirus-related endocervical adenocarcinoma",
+        "Glioblastoma",
         "Prostate carcinoma",
         "Osteosarcoma",
-        "Hepatoblastoma",
         "Childhood T acute lymphoblastic leukemia",
-        "Human papillomavirus-related endocervical adenocarcinoma",
-        "Chronic myelogenous leukemia, BCR-ABL1 positive",
         "Lung adenocarcinoma",
-        "Glioblastoma",
+        "Chronic myelogenous leukemia, BCR-ABL1 positive",
         "Invasive ductal carcinoma, not otherwise specified",
-        "Colon carcinoma"
+        "Hepatoblastoma"
       ],
       "instruments": [
         "LTQ Orbitrap Velos"
@@ -2025,8 +1998,8 @@
       "file": "PXD002756.sdrf.tsv",
       "filename": "PXD002756.sdrf.tsv",
       "path": "datasets/PXD002756/PXD002756.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002756/PXD002756.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002756/PXD002756.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002756/PXD002756.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002756/PXD002756.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 29,
       "organisms": [
@@ -2049,8 +2022,8 @@
       "file": "PXD002815.sdrf.tsv",
       "filename": "PXD002815.sdrf.tsv",
       "path": "datasets/PXD002815/PXD002815.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002815/PXD002815.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002815/PXD002815.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002815/PXD002815.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002815/PXD002815.sdrf.tsv",
       "num_samples": 4311,
       "num_columns": 21,
       "organisms": [
@@ -2074,8 +2047,8 @@
       "file": "PXD002870.sdrf.tsv",
       "filename": "PXD002870.sdrf.tsv",
       "path": "datasets/PXD002870/PXD002870.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002870/PXD002870.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002870/PXD002870.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002870/PXD002870.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002870/PXD002870.sdrf.tsv",
       "num_samples": 1477,
       "num_columns": 33,
       "organisms": [
@@ -2098,8 +2071,8 @@
       "file": "PXD003028.sdrf.tsv",
       "filename": "PXD003028.sdrf.tsv",
       "path": "datasets/PXD003028/PXD003028.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003028/PXD003028.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003028/PXD003028.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003028/PXD003028.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003028/PXD003028.sdrf.tsv",
       "num_samples": 89,
       "num_columns": 35,
       "organisms": [
@@ -2122,8 +2095,8 @@
       "file": "PXD003133.sdrf.tsv",
       "filename": "PXD003133.sdrf.tsv",
       "path": "datasets/PXD003133/PXD003133.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003133/PXD003133.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003133/PXD003133.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003133/PXD003133.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003133/PXD003133.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 28,
       "organisms": [
@@ -2146,8 +2119,8 @@
       "file": "PXD003209.sdrf.tsv",
       "filename": "PXD003209.sdrf.tsv",
       "path": "datasets/PXD003209/PXD003209.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003209/PXD003209.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003209/PXD003209.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003209/PXD003209.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003209/PXD003209.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 29,
       "organisms": [
@@ -2172,16 +2145,16 @@
       "file": "PXD003430.sdrf.tsv",
       "filename": "PXD003430.sdrf.tsv",
       "path": "datasets/PXD003430/PXD003430.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003430/PXD003430.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003430/PXD003430.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003430/PXD003430.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003430/PXD003430.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2199,16 +2172,16 @@
       "file": "PXD003452.sdrf.tsv",
       "filename": "PXD003452.sdrf.tsv",
       "path": "datasets/PXD003452/PXD003452.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003452/PXD003452.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003452/PXD003452.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003452/PXD003452.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003452/PXD003452.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2226,35 +2199,35 @@
       "file": "PXD003469.sdrf.tsv",
       "filename": "PXD003469.sdrf.tsv",
       "path": "datasets/PXD003469/PXD003469.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003469/PXD003469.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003469/PXD003469.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003469/PXD003469.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003469/PXD003469.sdrf.tsv",
       "num_samples": 382,
       "num_columns": 34,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "Burkitt's lymphoma (American)",
-        "diffuse histiocytic lymphoma",
-        "Primary mediastinal large B-cell lymphoma",
-        "Aggressive NK-cell leukemia",
-        "Anaplastic large cell lymphoma",
-        "Anaplastic large cell lymphoma,",
+        "malignant non-Hodgkin's lymphoma",
+        "Multiple Myeloma",
+        "Burkitt's lymphoma",
         "cutaneous T cell lymphoma",
         "Burkitt lymphoma",
-        "malignant non-Hodgkin's lymphoma",
-        "Transformed follicular lymphoma",
-        "Burkitt's lymphoma",
-        "Nodular lymphocyte predominant Hodgkin lymphoma",
-        "plasmacytoma",
-        "follicular lymphoma",
-        "acute T cell leukemia",
-        "Diffuse large B-cell lymphoma",
-        "Sezary Syndrome",
-        "lymphoma",
-        "Classical Hodgkin lymphoma",
+        "Aggressive NK-cell leukemia",
         "Mantle cell lymphoma",
-        "Multiple Myeloma"
+        "Anaplastic large cell lymphoma,",
+        "acute T cell leukemia",
+        "Sezary Syndrome",
+        "Transformed follicular lymphoma",
+        "plasmacytoma",
+        "Anaplastic large cell lymphoma",
+        "Classical Hodgkin lymphoma",
+        "follicular lymphoma",
+        "diffuse histiocytic lymphoma",
+        "Nodular lymphocyte predominant Hodgkin lymphoma",
+        "Diffuse large B-cell lymphoma",
+        "lymphoma",
+        "Primary mediastinal large B-cell lymphoma",
+        "Burkitt's lymphoma (American)"
       ],
       "instruments": [
         "LTQ Orbitrap XL"
@@ -2272,16 +2245,16 @@
       "file": "PXD003515.sdrf.tsv",
       "filename": "PXD003515.sdrf.tsv",
       "path": "datasets/PXD003515/PXD003515.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003515/PXD003515.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003515/PXD003515.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003515/PXD003515.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003515/PXD003515.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2299,20 +2272,20 @@
       "file": "PXD003531.sdrf.tsv",
       "filename": "PXD003531.sdrf.tsv",
       "path": "datasets/PXD003531/PXD003531.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003531/PXD003531.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003531/PXD003531.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003531/PXD003531.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003531/PXD003531.sdrf.tsv",
       "num_samples": 59,
       "num_columns": 36,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "high grade serous ovarian cancer",
-        "epithelial ovarian cancer"
+        "epithelial ovarian cancer",
+        "high grade serous ovarian cancer"
       ],
       "instruments": [
-        "Q Exactive HF-X",
-        "Q Exactive"
+        "Q Exactive",
+        "Q Exactive HF-X"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -2327,45 +2300,45 @@
       "file": "PXD003539.sdrf.tsv",
       "filename": "PXD003539.sdrf.tsv",
       "path": "datasets/PXD003539/PXD003539.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003539/PXD003539.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003539/PXD003539.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003539/PXD003539.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003539/PXD003539.sdrf.tsv",
       "num_samples": 120,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "breast carcinoma",
-        "prostate adenocarcinoma",
-        "malignant melanoma",
-        "large cell lung carcinoma",
-        "mesothelioma",
-        "breast ductal adenocarcinoma",
-        "ovarian carcinoma",
-        "breast adenocarcinoma",
-        "colon adenocarcinoma",
-        "clear cell renal carcinoma",
-        "acute lymphoblastic leukemia",
-        "melanoma",
-        "renal cell adenocarcinoma",
-        "immunoblastic large cell lymphoma",
-        "acute T lymphoblastic leukaemia",
-        "ovarian serous cystadenocarcinoma",
-        "colon carcinoma",
-        "ovarian adenocarcinoma",
-        "skin cutaneous melanoma",
-        "glioma",
-        "chronic myelogenic leukemia",
-        "promyelocytic leukemia",
         "lung carcinoma",
+        "mesothelioma",
+        "large cell lung carcinoma",
+        "promyelocytic leukemia",
+        "breast ductal adenocarcinoma",
+        "non-small cell lung carcinoma",
+        "breast carcinoma",
+        "ovarian carcinoma",
+        "acute lymphoblastic leukemia",
+        "ovarian adenocarcinoma",
         "renal cell carcinoma",
-        "plasmacytoma",
-        "renal clear cell adenocarcinoma",
-        "glioblastoma",
-        "renal adenocarcinoma",
         "renal carcinoma",
+        "renal clear cell adenocarcinoma",
+        "melanoma",
+        "clear cell renal carcinoma",
+        "prostate adenocarcinoma",
+        "immunoblastic large cell lymphoma",
+        "chronic myelogenic leukemia",
+        "colon adenocarcinoma",
+        "renal adenocarcinoma",
+        "plasmacytoma",
         "astrocytoma",
-        "non-small cell lung carcinoma"
+        "skin cutaneous melanoma",
+        "malignant melanoma",
+        "ovarian serous cystadenocarcinoma",
+        "glioma",
+        "glioblastoma",
+        "breast adenocarcinoma",
+        "colon carcinoma",
+        "acute T lymphoblastic leukaemia",
+        "renal cell adenocarcinoma"
       ],
       "instruments": [
         "TripleTOF 5600"
@@ -2383,8 +2356,8 @@
       "file": "PXD003615.sdrf.tsv",
       "filename": "PXD003615.sdrf.tsv",
       "path": "datasets/PXD003615/PXD003615.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003615/PXD003615.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003615/PXD003615.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003615/PXD003615.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003615/PXD003615.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 33,
       "organisms": [
@@ -2409,16 +2382,16 @@
       "file": "PXD003636.sdrf.tsv",
       "filename": "PXD003636.sdrf.tsv",
       "path": "datasets/PXD003636/PXD003636.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003636/PXD003636.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003636/PXD003636.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003636/PXD003636.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003636/PXD003636.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2436,8 +2409,8 @@
       "file": "PXD003668.sdrf.tsv",
       "filename": "PXD003668.sdrf.tsv",
       "path": "datasets/PXD003668/PXD003668.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003668/PXD003668.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003668/PXD003668.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003668/PXD003668.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003668/PXD003668.sdrf.tsv",
       "num_samples": 101,
       "num_columns": 30,
       "organisms": [
@@ -2462,8 +2435,8 @@
       "file": "PXD003977.sdrf.tsv",
       "filename": "PXD003977.sdrf.tsv",
       "path": "datasets/PXD003977/PXD003977.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003977/PXD003977.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003977/PXD003977.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003977/PXD003977.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003977/PXD003977.sdrf.tsv",
       "num_samples": 120,
       "num_columns": 31,
       "organisms": [
@@ -2488,16 +2461,16 @@
       "file": "PXD004132.sdrf.tsv",
       "filename": "PXD004132.sdrf.tsv",
       "path": "datasets/PXD004132/PXD004132.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004132/PXD004132.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004132/PXD004132.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004132/PXD004132.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004132/PXD004132.sdrf.tsv",
       "num_samples": 23,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2515,8 +2488,8 @@
       "file": "PXD004143.sdrf.tsv",
       "filename": "PXD004143.sdrf.tsv",
       "path": "datasets/PXD004143/PXD004143.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004143/PXD004143.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004143/PXD004143.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004143/PXD004143.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004143/PXD004143.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 31,
       "organisms": [
@@ -2539,8 +2512,8 @@
       "file": "PXD004159.sdrf.tsv",
       "filename": "PXD004159.sdrf.tsv",
       "path": "datasets/PXD004159/PXD004159.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004159/PXD004159.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004159/PXD004159.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004159/PXD004159.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004159/PXD004159.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 33,
       "organisms": [
@@ -2565,16 +2538,16 @@
       "file": "PXD004242.sdrf.tsv",
       "filename": "PXD004242.sdrf.tsv",
       "path": "datasets/PXD004242/PXD004242.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004242/PXD004242.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004242/PXD004242.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004242/PXD004242.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004242/PXD004242.sdrf.tsv",
       "num_samples": 1290,
       "num_columns": 37,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "uninfected",
-        "obesity"
+        "obesity",
+        "uninfected"
       ],
       "instruments": [
         "Q Exactive HF"
@@ -2592,8 +2565,8 @@
       "file": "PXD004332.sdrf.tsv",
       "filename": "PXD004332.sdrf.tsv",
       "path": "datasets/PXD004332/PXD004332.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004332/PXD004332.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004332/PXD004332.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004332/PXD004332.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004332/PXD004332.sdrf.tsv",
       "num_samples": 61,
       "num_columns": 32,
       "organisms": [
@@ -2616,8 +2589,8 @@
       "file": "PXD004436.sdrf.tsv",
       "filename": "PXD004436.sdrf.tsv",
       "path": "datasets/PXD004436/PXD004436.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004436/PXD004436.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004436/PXD004436.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004436/PXD004436.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004436/PXD004436.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 24,
       "organisms": [
@@ -2627,8 +2600,8 @@
         "none"
       ],
       "instruments": [
-        "Q Exactive Plus",
-        "LTQ Velos"
+        "LTQ Velos",
+        "Q Exactive Plus"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -2643,8 +2616,8 @@
       "file": "PXD004452-celllines.sdrf.tsv",
       "filename": "PXD004452-celllines.sdrf.tsv",
       "path": "datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
       "num_samples": 761,
       "num_columns": 38,
       "organisms": [
@@ -2652,10 +2625,10 @@
       ],
       "diseases": [
         "lung adenocarcinoma",
-        "colon cancer",
-        "neuroblastoma",
         "breast cancer",
-        "epithelial cervix carcinoma"
+        "epithelial cervix carcinoma",
+        "colon cancer",
+        "neuroblastoma"
       ],
       "instruments": [
         "Q Exactive"
@@ -2673,8 +2646,8 @@
       "file": "PXD004452-tissues.sdrf.tsv",
       "filename": "PXD004452-tissues.sdrf.tsv",
       "path": "datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
       "num_samples": 216,
       "num_columns": 35,
       "organisms": [
@@ -2697,8 +2670,8 @@
       "file": "PXD004528.sdrf.tsv",
       "filename": "PXD004528.sdrf.tsv",
       "path": "datasets/PXD004528/PXD004528.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004528/PXD004528.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004528/PXD004528.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004528/PXD004528.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004528/PXD004528.sdrf.tsv",
       "num_samples": 5,
       "num_columns": 24,
       "organisms": [
@@ -2721,8 +2694,8 @@
       "file": "PXD004603.sdrf.tsv",
       "filename": "PXD004603.sdrf.tsv",
       "path": "datasets/PXD004603/PXD004603.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004603/PXD004603.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004603/PXD004603.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004603/PXD004603.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004603/PXD004603.sdrf.tsv",
       "num_samples": 23,
       "num_columns": 26,
       "organisms": [
@@ -2745,8 +2718,8 @@
       "file": "PXD004604.sdrf.tsv",
       "filename": "PXD004604.sdrf.tsv",
       "path": "datasets/PXD004604/PXD004604.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004604/PXD004604.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004604/PXD004604.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004604/PXD004604.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004604/PXD004604.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 26,
       "organisms": [
@@ -2769,8 +2742,8 @@
       "file": "PXD004605.sdrf.tsv",
       "filename": "PXD004605.sdrf.tsv",
       "path": "datasets/PXD004605/PXD004605.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004605/PXD004605.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004605/PXD004605.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004605/PXD004605.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004605/PXD004605.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 23,
       "organisms": [
@@ -2793,8 +2766,8 @@
       "file": "PXD004613.sdrf.tsv",
       "filename": "PXD004613.sdrf.tsv",
       "path": "datasets/PXD004613/PXD004613.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004613/PXD004613.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004613/PXD004613.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004613/PXD004613.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004613/PXD004613.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 35,
       "organisms": [
@@ -2819,8 +2792,8 @@
       "file": "PXD004616.sdrf.tsv",
       "filename": "PXD004616.sdrf.tsv",
       "path": "datasets/PXD004616/PXD004616.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004616/PXD004616.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004616/PXD004616.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004616/PXD004616.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004616/PXD004616.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 27,
       "organisms": [
@@ -2843,8 +2816,8 @@
       "file": "PXD004617.sdrf.tsv",
       "filename": "PXD004617.sdrf.tsv",
       "path": "datasets/PXD004617/PXD004617.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004617/PXD004617.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004617/PXD004617.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004617/PXD004617.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004617/PXD004617.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 27,
       "organisms": [
@@ -2867,8 +2840,8 @@
       "file": "PXD004618.sdrf.tsv",
       "filename": "PXD004618.sdrf.tsv",
       "path": "datasets/PXD004618/PXD004618.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004618/PXD004618.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004618/PXD004618.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004618/PXD004618.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004618/PXD004618.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 28,
       "organisms": [
@@ -2891,8 +2864,8 @@
       "file": "PXD004624.sdrf.tsv",
       "filename": "PXD004624.sdrf.tsv",
       "path": "datasets/PXD004624/PXD004624.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004624/PXD004624.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004624/PXD004624.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004624/PXD004624.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004624/PXD004624.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 35,
       "organisms": [
@@ -2917,16 +2890,16 @@
       "file": "PXD004682.sdrf.tsv",
       "filename": "PXD004682.sdrf.tsv",
       "path": "datasets/PXD004682/PXD004682.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004682/PXD004682.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004682/PXD004682.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004682/PXD004682.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004682/PXD004682.sdrf.tsv",
       "num_samples": 192,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "squamous  cell carcinoma"
+        "squamous  cell carcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive Plus"
@@ -2944,8 +2917,8 @@
       "file": "PXD004683.sdrf.tsv",
       "filename": "PXD004683.sdrf.tsv",
       "path": "datasets/PXD004683/PXD004683.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004683/PXD004683.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004683/PXD004683.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004683/PXD004683.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004683/PXD004683.sdrf.tsv",
       "num_samples": 192,
       "num_columns": 29,
       "organisms": [
@@ -2970,16 +2943,16 @@
       "file": "PXD004684.sdrf.tsv",
       "filename": "PXD004684.sdrf.tsv",
       "path": "datasets/PXD004684/PXD004684.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004684/PXD004684.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004684/PXD004684.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004684/PXD004684.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004684/PXD004684.sdrf.tsv",
       "num_samples": 16,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "squamous cell carcinoma"
+        "squamous cell carcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive Plus"
@@ -2997,8 +2970,8 @@
       "file": "PXD004705.sdrf.tsv",
       "filename": "PXD004705.sdrf.tsv",
       "path": "datasets/PXD004705/PXD004705.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004705/PXD004705.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004705/PXD004705.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004705/PXD004705.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004705/PXD004705.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 28,
       "organisms": [
@@ -3021,8 +2994,8 @@
       "file": "PXD004732.sdrf.tsv",
       "filename": "PXD004732.sdrf.tsv",
       "path": "datasets/PXD004732/PXD004732.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004732/PXD004732.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004732/PXD004732.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004732/PXD004732.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004732/PXD004732.sdrf.tsv",
       "num_samples": 1460,
       "num_columns": 40,
       "organisms": [
@@ -3045,8 +3018,8 @@
       "file": "PXD004903.sdrf.tsv",
       "filename": "PXD004903.sdrf.tsv",
       "path": "datasets/PXD004903/PXD004903.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004903/PXD004903.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004903/PXD004903.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004903/PXD004903.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004903/PXD004903.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 29,
       "organisms": [
@@ -3071,8 +3044,8 @@
       "file": "PXD004939.sdrf.tsv",
       "filename": "PXD004939.sdrf.tsv",
       "path": "datasets/PXD004939/PXD004939.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004939/PXD004939.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004939/PXD004939.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004939/PXD004939.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004939/PXD004939.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 27,
       "organisms": [
@@ -3095,8 +3068,8 @@
       "file": "PXD004987.sdrf.tsv",
       "filename": "PXD004987.sdrf.tsv",
       "path": "datasets/PXD004987/PXD004987.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004987/PXD004987.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004987/PXD004987.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004987/PXD004987.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004987/PXD004987.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 25,
       "organisms": [
@@ -3119,8 +3092,8 @@
       "file": "PXD005163.sdrf.tsv",
       "filename": "PXD005163.sdrf.tsv",
       "path": "datasets/PXD005163/PXD005163.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005163/PXD005163.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005163/PXD005163.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005163/PXD005163.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005163/PXD005163.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 30,
       "organisms": [
@@ -3145,8 +3118,8 @@
       "file": "PXD005171.sdrf.tsv",
       "filename": "PXD005171.sdrf.tsv",
       "path": "datasets/PXD005171/PXD005171.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005171/PXD005171.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005171/PXD005171.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005171/PXD005171.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005171/PXD005171.sdrf.tsv",
       "num_samples": 100,
       "num_columns": 31,
       "organisms": [
@@ -3171,8 +3144,8 @@
       "file": "PXD005172.sdrf.tsv",
       "filename": "PXD005172.sdrf.tsv",
       "path": "datasets/PXD005172/PXD005172.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005172/PXD005172.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005172/PXD005172.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005172/PXD005172.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005172/PXD005172.sdrf.tsv",
       "num_samples": 100,
       "num_columns": 31,
       "organisms": [
@@ -3197,16 +3170,16 @@
       "file": "PXD005173.sdrf.tsv",
       "filename": "PXD005173.sdrf.tsv",
       "path": "datasets/PXD005173/PXD005173.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005173/PXD005173.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005173/PXD005173.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005173/PXD005173.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005173/PXD005173.sdrf.tsv",
       "num_samples": 59,
       "num_columns": 28,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "Colorectal cancer",
-        "Normal Colorectum"
+        "Normal Colorectum",
+        "Colorectal cancer"
       ],
       "instruments": [
         "LTQ Orbitrap Velos"
@@ -3224,8 +3197,8 @@
       "file": "PXD005174.sdrf.tsv",
       "filename": "PXD005174.sdrf.tsv",
       "path": "datasets/PXD005174/PXD005174.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005174/PXD005174.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005174/PXD005174.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005174/PXD005174.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005174/PXD005174.sdrf.tsv",
       "num_samples": 128,
       "num_columns": 33,
       "organisms": [
@@ -3250,8 +3223,8 @@
       "file": "PXD005175.sdrf.tsv",
       "filename": "PXD005175.sdrf.tsv",
       "path": "datasets/PXD005175/PXD005175.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005175/PXD005175.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005175/PXD005175.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005175/PXD005175.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005175/PXD005175.sdrf.tsv",
       "num_samples": 120,
       "num_columns": 29,
       "organisms": [
@@ -3276,8 +3249,8 @@
       "file": "PXD005176.sdrf.tsv",
       "filename": "PXD005176.sdrf.tsv",
       "path": "datasets/PXD005176/PXD005176.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005176/PXD005176.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005176/PXD005176.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005176/PXD005176.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005176/PXD005176.sdrf.tsv",
       "num_samples": 114,
       "num_columns": 31,
       "organisms": [
@@ -3302,8 +3275,8 @@
       "file": "PXD005177.sdrf.tsv",
       "filename": "PXD005177.sdrf.tsv",
       "path": "datasets/PXD005177/PXD005177.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005177/PXD005177.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005177/PXD005177.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005177/PXD005177.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005177/PXD005177.sdrf.tsv",
       "num_samples": 136,
       "num_columns": 32,
       "organisms": [
@@ -3328,8 +3301,8 @@
       "file": "PXD005207.sdrf.tsv",
       "filename": "PXD005207.sdrf.tsv",
       "path": "datasets/PXD005207/PXD005207.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005207/PXD005207.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005207/PXD005207.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005207/PXD005207.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005207/PXD005207.sdrf.tsv",
       "num_samples": 258,
       "num_columns": 34,
       "organisms": [
@@ -3352,8 +3325,8 @@
       "file": "PXD005241.sdrf.tsv",
       "filename": "PXD005241.sdrf.tsv",
       "path": "datasets/PXD005241/PXD005241.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005241/PXD005241.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005241/PXD005241.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005241/PXD005241.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005241/PXD005241.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 29,
       "organisms": [
@@ -3376,8 +3349,8 @@
       "file": "PXD005300.sdrf.tsv",
       "filename": "PXD005300.sdrf.tsv",
       "path": "datasets/PXD005300/PXD005300.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005300/PXD005300.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005300/PXD005300.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005300/PXD005300.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005300/PXD005300.sdrf.tsv",
       "num_samples": 128,
       "num_columns": 30,
       "organisms": [
@@ -3400,8 +3373,8 @@
       "file": "PXD005354.sdrf.tsv",
       "filename": "PXD005354.sdrf.tsv",
       "path": "datasets/PXD005354/PXD005354.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005354/PXD005354.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005354/PXD005354.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005354/PXD005354.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005354/PXD005354.sdrf.tsv",
       "num_samples": 1560,
       "num_columns": 30,
       "organisms": [
@@ -3426,8 +3399,8 @@
       "file": "PXD005355.sdrf.tsv",
       "filename": "PXD005355.sdrf.tsv",
       "path": "datasets/PXD005355/PXD005355.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005355/PXD005355.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005355/PXD005355.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005355/PXD005355.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005355/PXD005355.sdrf.tsv",
       "num_samples": 195,
       "num_columns": 30,
       "organisms": [
@@ -3452,8 +3425,8 @@
       "file": "PXD005366-hela.sdrf.tsv",
       "filename": "PXD005366-hela.sdrf.tsv",
       "path": "datasets/PXD005366/PXD005366-hela.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005366/PXD005366-hela.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005366/PXD005366-hela.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005366/PXD005366-hela.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005366/PXD005366-hela.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 39,
       "organisms": [
@@ -3478,8 +3451,8 @@
       "file": "PXD005366-rattus.sdrf.tsv",
       "filename": "PXD005366-rattus.sdrf.tsv",
       "path": "datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
       "num_samples": 28,
       "num_columns": 39,
       "organisms": [
@@ -3502,8 +3475,8 @@
       "file": "PXD005366.sdrf.tsv",
       "filename": "PXD005366.sdrf.tsv",
       "path": "datasets/PXD005366/PXD005366.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005366/PXD005366.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005366/PXD005366.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005366/PXD005366.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005366/PXD005366.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 39,
       "organisms": [
@@ -3528,8 +3501,8 @@
       "file": "PXD005445.sdrf.tsv",
       "filename": "PXD005445.sdrf.tsv",
       "path": "datasets/PXD005445/PXD005445.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005445/PXD005445.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005445/PXD005445.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005445/PXD005445.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005445/PXD005445.sdrf.tsv",
       "num_samples": 196,
       "num_columns": 35,
       "organisms": [
@@ -3554,8 +3527,8 @@
       "file": "PXD005463.sdrf.tsv",
       "filename": "PXD005463.sdrf.tsv",
       "path": "datasets/PXD005463/PXD005463.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005463/PXD005463.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005463/PXD005463.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005463/PXD005463.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005463/PXD005463.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 29,
       "organisms": [
@@ -3578,8 +3551,8 @@
       "file": "PXD005507.sdrf.tsv",
       "filename": "PXD005507.sdrf.tsv",
       "path": "datasets/PXD005507/PXD005507.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005507/PXD005507.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005507/PXD005507.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005507/PXD005507.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005507/PXD005507.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 32,
       "organisms": [
@@ -3604,16 +3577,16 @@
       "file": "PXD005539.sdrf.tsv",
       "filename": "PXD005539.sdrf.tsv",
       "path": "datasets/PXD005539/PXD005539.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005539/PXD005539.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005539/PXD005539.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005539/PXD005539.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005539/PXD005539.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "amelanotic melanoma",
-        "malignant melanoma"
+        "malignant melanoma",
+        "amelanotic melanoma"
       ],
       "instruments": [
         " Orbitrap Elite"
@@ -3631,16 +3604,16 @@
       "file": "PXD005554.sdrf.tsv",
       "filename": "PXD005554.sdrf.tsv",
       "path": "datasets/PXD005554/PXD005554.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005554/PXD005554.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005554/PXD005554.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005554/PXD005554.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005554/PXD005554.sdrf.tsv",
       "num_samples": 142,
       "num_columns": 39,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "triple-negative breast cancer",
-        "metastatic ovarian high grade serous adenocarcinoma"
+        "metastatic ovarian high grade serous adenocarcinoma",
+        "triple-negative breast cancer"
       ],
       "instruments": [
         "Q Exactive"
@@ -3658,8 +3631,8 @@
       "file": "PXD005780.sdrf.tsv",
       "filename": "PXD005780.sdrf.tsv",
       "path": "datasets/PXD005780/PXD005780.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005780/PXD005780.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005780/PXD005780.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005780/PXD005780.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005780/PXD005780.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 31,
       "organisms": [
@@ -3682,8 +3655,8 @@
       "file": "PXD005819.sdrf.tsv",
       "filename": "PXD005819.sdrf.tsv",
       "path": "datasets/PXD005819/PXD005819.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005819/PXD005819.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005819/PXD005819.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005819/PXD005819.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005819/PXD005819.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 33,
       "organisms": [
@@ -3706,23 +3679,23 @@
       "file": "PXD005940.sdrf.tsv",
       "filename": "PXD005940.sdrf.tsv",
       "path": "datasets/PXD005940/PXD005940.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005940/PXD005940.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005940/PXD005940.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005940/PXD005940.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005940/PXD005940.sdrf.tsv",
       "num_samples": 216,
       "num_columns": 36,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "colon adenocarcinoma",
+        "astrocytoma",
         "prostate carcinoma",
         "invasive ductal carcinoma",
         "amelanotic melanoma",
+        "non-small cell lung adenocarcinoma",
         "childhood T acute lymphoblastic leukemia",
         "renal cell carcinoma",
-        "astrocytoma",
         "ovarian serous cystadenocarcinoma",
-        "non-small cell lung adenocarcinoma"
+        "colon adenocarcinoma"
       ],
       "instruments": [
         "Orbitrap Elite"
@@ -3740,42 +3713,42 @@
       "file": "PXD005942.sdrf.tsv",
       "filename": "PXD005942.sdrf.tsv",
       "path": "datasets/PXD005942/PXD005942.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005942/PXD005942.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005942/PXD005942.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005942/PXD005942.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005942/PXD005942.sdrf.tsv",
       "num_samples": 59,
       "num_columns": 31,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "prostate carcinoma",
-        "adult acute myeloid leukemia",
-        "breast adenocarcinoma",
-        "colon adenocarcinoma",
-        "childhood T acute lymphoblastic leukemia",
-        "Colon adenocarcinoma",
-        "clear cell renal carcinoma",
-        "melanoma",
-        "chronic myelogenous leukemia",
-        "Pleural Epithelioid Mesothelioma",
-        "metastatic melanoma",
-        "anaplastic large cell lymphoma",
-        "adult T acute lymphoblastic leukemia",
-        "ovarian serous cystadenocarcinoma",
-        "non-small cell lung adenocarcinoma",
-        "colon carcinoma",
-        "renal cell carcinoma",
-        "brain glioblastoma",
-        "gliosarcoma",
         "cutaneous melanoma",
         "multiple myeloma",
+        "metastatic melanoma",
+        "adult T acute lymphoblastic leukemia",
+        "non-small cell lung carcinoma",
+        "Pleural Epithelioid Mesothelioma",
         "lung adenocarcinoma",
         "invasive ductal carcinoma",
-        "amelanotic melanoma",
+        "non-small cell lung adenocarcinoma",
+        "renal cell carcinoma",
         "high grade ovarian serous adenocarcinoma",
+        "brain glioblastoma",
+        "gliosarcoma",
+        "adult acute myeloid leukemia",
+        "melanoma",
+        "prostate carcinoma",
+        "clear cell renal carcinoma",
+        "childhood T acute lymphoblastic leukemia",
+        "colon adenocarcinoma",
         "astrocytoma",
-        "non-small cell lung carcinoma",
-        "Ovarian Endometrioid Adenocarcinoma"
+        "amelanotic melanoma",
+        "ovarian serous cystadenocarcinoma",
+        "breast adenocarcinoma",
+        "anaplastic large cell lymphoma",
+        "Colon adenocarcinoma",
+        "colon carcinoma",
+        "Ovarian Endometrioid Adenocarcinoma",
+        "chronic myelogenous leukemia"
       ],
       "instruments": [
         "LTQ Orbitrap XL ETD"
@@ -3793,42 +3766,42 @@
       "file": "PXD005946.sdrf.tsv",
       "filename": "PXD005946.sdrf.tsv",
       "path": "datasets/PXD005946/PXD005946.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005946/PXD005946.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005946/PXD005946.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005946/PXD005946.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005946/PXD005946.sdrf.tsv",
       "num_samples": 732,
       "num_columns": 35,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "prostate carcinoma",
-        "adult acute myeloid leukemia",
-        "breast adenocarcinoma",
-        "colon adenocarcinoma",
-        "childhood T acute lymphoblastic leukemia",
-        "clear cell renal carcinoma",
-        "rectosigmoid adenocarcinoma",
-        "melanoma",
-        "chronic myelogenous leukemia",
-        "Pleural Epithelioid Mesothelioma",
-        "metastatic melanoma",
-        "anaplastic large cell lymphoma",
-        "adult T acute lymphoblastic leukemia",
-        "ovarian serous cystadenocarcinoma",
-        "non-small cell lung adenocarcinoma",
-        "colon carcinoma",
-        "renal cell carcinoma",
-        "brain glioblastoma",
-        "gliosarcoma",
         "cutaneous melanoma",
         "multiple myeloma",
-        "invasive ductal carcinoma",
-        "lung adenocarcinoma",
-        "amelanotic melanoma",
-        "high grade ovarian serous adenocarcinoma",
-        "astrocytoma",
+        "metastatic melanoma",
+        "Pleural Epithelioid Mesothelioma",
         "non-small cell lung carcinoma",
-        "Ovarian Endometrioid Adenocarcinoma"
+        "adult T acute lymphoblastic leukemia",
+        "lung adenocarcinoma",
+        "invasive ductal carcinoma",
+        "non-small cell lung adenocarcinoma",
+        "renal cell carcinoma",
+        "brain glioblastoma",
+        "high grade ovarian serous adenocarcinoma",
+        "gliosarcoma",
+        "adult acute myeloid leukemia",
+        "melanoma",
+        "prostate carcinoma",
+        "rectosigmoid adenocarcinoma",
+        "clear cell renal carcinoma",
+        "childhood T acute lymphoblastic leukemia",
+        "colon adenocarcinoma",
+        "astrocytoma",
+        "amelanotic melanoma",
+        "ovarian serous cystadenocarcinoma",
+        "breast adenocarcinoma",
+        "anaplastic large cell lymphoma",
+        "colon carcinoma",
+        "Ovarian Endometrioid Adenocarcinoma",
+        "chronic myelogenous leukemia"
       ],
       "instruments": [
         "LTQ Orbitrap XL ETD"
@@ -3846,8 +3819,8 @@
       "file": "PXD006003.sdrf.tsv",
       "filename": "PXD006003.sdrf.tsv",
       "path": "datasets/PXD006003/PXD006003.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006003/PXD006003.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006003/PXD006003.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006003/PXD006003.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006003/PXD006003.sdrf.tsv",
       "num_samples": 1346,
       "num_columns": 37,
       "organisms": [
@@ -3872,8 +3845,8 @@
       "file": "PXD006132.sdrf.tsv",
       "filename": "PXD006132.sdrf.tsv",
       "path": "datasets/PXD006132/PXD006132.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006132/PXD006132.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006132/PXD006132.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006132/PXD006132.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006132/PXD006132.sdrf.tsv",
       "num_samples": 49,
       "num_columns": 36,
       "organisms": [
@@ -3898,8 +3871,8 @@
       "file": "PXD006195.sdrf.tsv",
       "filename": "PXD006195.sdrf.tsv",
       "path": "datasets/PXD006195/PXD006195.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006195/PXD006195.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006195/PXD006195.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006195/PXD006195.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006195/PXD006195.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 36,
       "organisms": [
@@ -3922,8 +3895,8 @@
       "file": "PXD006233.sdrf.tsv",
       "filename": "PXD006233.sdrf.tsv",
       "path": "datasets/PXD006233/PXD006233.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006233/PXD006233.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006233/PXD006233.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006233/PXD006233.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006233/PXD006233.sdrf.tsv",
       "num_samples": 378,
       "num_columns": 29,
       "organisms": [
@@ -3948,13 +3921,13 @@
       "file": "PXD006401.sdrf.tsv",
       "filename": "PXD006401.sdrf.tsv",
       "path": "datasets/PXD006401/PXD006401.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006401/PXD006401.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006401/PXD006401.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006401/PXD006401.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006401/PXD006401.sdrf.tsv",
       "num_samples": 28,
       "num_columns": 32,
       "organisms": [
-        "homo sapiens",
-        "mus musculus"
+        "mus musculus",
+        "homo sapiens"
       ],
       "diseases": [],
       "instruments": [
@@ -3973,8 +3946,8 @@
       "file": "PXD006430-silac.sdrf.tsv",
       "filename": "PXD006430-silac.sdrf.tsv",
       "path": "datasets/PXD006430/PXD006430-silac.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006430/PXD006430-silac.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006430/PXD006430-silac.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006430/PXD006430-silac.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006430/PXD006430-silac.sdrf.tsv",
       "num_samples": 576,
       "num_columns": 36,
       "organisms": [
@@ -3984,8 +3957,8 @@
         "breast cancer"
       ],
       "instruments": [
-        "LTQ Orbitrap Velos",
-        "Q Exactive"
+        "Q Exactive",
+        "LTQ Orbitrap Velos"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -4000,8 +3973,8 @@
       "file": "PXD006430-tmt.sdrf.tsv",
       "filename": "PXD006430-tmt.sdrf.tsv",
       "path": "datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
       "num_samples": 720,
       "num_columns": 32,
       "organisms": [
@@ -4026,8 +3999,8 @@
       "file": "PXD006482.sdrf.tsv",
       "filename": "PXD006482.sdrf.tsv",
       "path": "datasets/PXD006482/PXD006482.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006482/PXD006482.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006482/PXD006482.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006482/PXD006482.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006482/PXD006482.sdrf.tsv",
       "num_samples": 192,
       "num_columns": 36,
       "organisms": [
@@ -4052,8 +4025,8 @@
       "file": "PXD006542.sdrf.tsv",
       "filename": "PXD006542.sdrf.tsv",
       "path": "datasets/PXD006542/PXD006542.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006542/PXD006542.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006542/PXD006542.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006542/PXD006542.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006542/PXD006542.sdrf.tsv",
       "num_samples": 1488,
       "num_columns": 30,
       "organisms": [
@@ -4078,8 +4051,8 @@
       "file": "PXD006607.sdrf.tsv",
       "filename": "PXD006607.sdrf.tsv",
       "path": "datasets/PXD006607/PXD006607.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006607/PXD006607.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006607/PXD006607.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006607/PXD006607.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006607/PXD006607.sdrf.tsv",
       "num_samples": 1028,
       "num_columns": 37,
       "organisms": [
@@ -4104,8 +4077,8 @@
       "file": "PXD006675.sdrf.tsv",
       "filename": "PXD006675.sdrf.tsv",
       "path": "datasets/PXD006675/PXD006675.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006675/PXD006675.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006675/PXD006675.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006675/PXD006675.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006675/PXD006675.sdrf.tsv",
       "num_samples": 594,
       "num_columns": 30,
       "organisms": [
@@ -4131,8 +4104,8 @@
       "file": "PXD006877.sdrf.tsv",
       "filename": "PXD006877.sdrf.tsv",
       "path": "datasets/PXD006877/PXD006877.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006877/PXD006877.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006877/PXD006877.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006877/PXD006877.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006877/PXD006877.sdrf.tsv",
       "num_samples": 112,
       "num_columns": 25,
       "organisms": [
@@ -4155,8 +4128,8 @@
       "file": "PXD006914.sdrf.tsv",
       "filename": "PXD006914.sdrf.tsv",
       "path": "datasets/PXD006914/PXD006914.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006914/PXD006914.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006914/PXD006914.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006914/PXD006914.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006914/PXD006914.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 29,
       "organisms": [
@@ -4183,8 +4156,8 @@
       "file": "PXD007073.sdrf.tsv",
       "filename": "PXD007073.sdrf.tsv",
       "path": "datasets/PXD007073/PXD007073.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007073/PXD007073.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007073/PXD007073.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007073/PXD007073.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007073/PXD007073.sdrf.tsv",
       "num_samples": 136,
       "num_columns": 35,
       "organisms": [
@@ -4209,49 +4182,49 @@
       "file": "PXD007160.sdrf.tsv",
       "filename": "PXD007160.sdrf.tsv",
       "path": "datasets/PXD007160/PXD007160.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007160/PXD007160.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007160/PXD007160.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007160/PXD007160.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007160/PXD007160.sdrf.tsv",
       "num_samples": 1687,
       "num_columns": 32,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "Alzheimer's disease/Parkinson's disease6",
-        "Alzheimer's disease/Parkinson's disease",
-        "Alzheimer's disease 7",
-        "control3",
-        "Alzheimer's disease0",
         "Alzheimer's disease 8",
-        "Alzheimer's disease",
-        "Parkinson's disease",
-        "control6",
-        "control8",
-        "Parkinson's disease0",
-        "Alzheimer's disease/Parkinson's disease9",
-        "Parkinson's disease3",
-        "Alzheimer's disease 5",
-        "control7",
-        "Alzheimer's disease/Parkinson's disease8",
-        "Alzheimer's disease/Parkinson's disease5",
-        "Alzheimer's disease/Parkinson's disease7",
-        "Parkinson's disease9",
-        "Alzheimer's disease 3",
-        "Parkinson's disease7",
+        "Alzheimer's disease 6",
+        "Alzheimer's disease 4",
         "Alzheimer's disease/Parkinson's disease4",
+        "control6",
+        "Alzheimer's disease",
+        "Alzheimer's disease/Parkinson's disease8",
+        "Alzheimer's disease/Parkinson's disease7",
+        "Alzheimer's disease/Parkinson's disease0",
+        "Alzheimer's disease 5",
+        "Alzheimer's disease/Parkinson's disease6",
+        "control",
+        "Alzheimer's disease 7",
+        "Alzheimer's disease 3",
+        "Parkinson's disease3",
+        "Alzheimer's disease0",
+        "Alzheimer's disease/Parkinson's disease3",
         "Alzheimer's disease 9",
-        "control0",
+        "control5",
+        "Alzheimer's disease/Parkinson's disease",
+        "Parkinson's disease9",
+        "Parkinson's disease7",
+        "Alzheimer's disease/Parkinson's disease9",
+        "Alzheimer's disease/Parkinson's disease5",
+        "Parkinson's disease0",
         "Parkinson's disease4",
         "Parkinson's disease5",
-        "Alzheimer's disease/Parkinson's disease0",
-        "control4",
-        "Alzheimer's disease 4",
-        "Alzheimer's disease/Parkinson's disease3",
         "control9",
-        "control",
-        "Alzheimer's disease 6",
-        "control5",
+        "control0",
+        "control4",
+        "Parkinson's disease",
         "Parkinson's disease8",
+        "control3",
+        "control8",
+        "control7",
         "Parkinson's disease6"
       ],
       "instruments": [
@@ -4270,8 +4243,8 @@
       "file": "PXD007555.sdrf.tsv",
       "filename": "PXD007555.sdrf.tsv",
       "path": "datasets/PXD007555/PXD007555.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007555/PXD007555.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007555/PXD007555.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007555/PXD007555.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007555/PXD007555.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 30,
       "organisms": [
@@ -4296,8 +4269,8 @@
       "file": "PXD007662.sdrf.tsv",
       "filename": "PXD007662.sdrf.tsv",
       "path": "datasets/PXD007662/PXD007662.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007662/PXD007662.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007662/PXD007662.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007662/PXD007662.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007662/PXD007662.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 35,
       "organisms": [
@@ -4322,8 +4295,8 @@
       "file": "PXD007864.sdrf.tsv",
       "filename": "PXD007864.sdrf.tsv",
       "path": "datasets/PXD007864/PXD007864.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007864/PXD007864.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007864/PXD007864.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007864/PXD007864.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007864/PXD007864.sdrf.tsv",
       "num_samples": 2,
       "num_columns": 31,
       "organisms": [
@@ -4346,8 +4319,8 @@
       "file": "PXD008012.sdrf.tsv",
       "filename": "PXD008012.sdrf.tsv",
       "path": "datasets/PXD008012/PXD008012.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008012/PXD008012.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008012/PXD008012.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008012/PXD008012.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008012/PXD008012.sdrf.tsv",
       "num_samples": 141,
       "num_columns": 40,
       "organisms": [
@@ -4372,22 +4345,22 @@
       "file": "PXD008222.sdrf.tsv",
       "filename": "PXD008222.sdrf.tsv",
       "path": "datasets/PXD008222/PXD008222.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008222/PXD008222.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008222/PXD008222.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008222/PXD008222.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008222/PXD008222.sdrf.tsv",
       "num_samples": 456,
       "num_columns": 32,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "breast carcinoma",
         "fibrocystic disease",
-        "medulallary carcinoma",
         "primary breast tumor",
         "primary ductal carcinoma",
+        "medulallary carcinoma",
         "ductal carcinoma",
-        "metastatic carcinoma",
-        "primary acantholytic squamous cell carcinoma"
+        "primary acantholytic squamous cell carcinoma",
+        "breast carcinoma",
+        "metastatic carcinoma"
       ],
       "instruments": [
         "Q Exactive"
@@ -4405,8 +4378,8 @@
       "file": "PXD008355.sdrf.tsv",
       "filename": "PXD008355.sdrf.tsv",
       "path": "datasets/PXD008355/PXD008355.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008355/PXD008355.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008355/PXD008355.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008355/PXD008355.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008355/PXD008355.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 35,
       "organisms": [
@@ -4429,8 +4402,8 @@
       "file": "PXD008369.sdrf.tsv",
       "filename": "PXD008369.sdrf.tsv",
       "path": "datasets/PXD008369/PXD008369.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008369/PXD008369.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008369/PXD008369.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008369/PXD008369.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008369/PXD008369.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 36,
       "organisms": [
@@ -4453,8 +4426,8 @@
       "file": "PXD008440.sdrf.tsv",
       "filename": "PXD008440.sdrf.tsv",
       "path": "datasets/PXD008440/PXD008440.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008440/PXD008440.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008440/PXD008440.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008440/PXD008440.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008440/PXD008440.sdrf.tsv",
       "num_samples": 200,
       "num_columns": 32,
       "organisms": [
@@ -4479,8 +4452,8 @@
       "file": "PXD008722.sdrf.tsv",
       "filename": "PXD008722.sdrf.tsv",
       "path": "datasets/PXD008722/PXD008722.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008722/PXD008722.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008722/PXD008722.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008722/PXD008722.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008722/PXD008722.sdrf.tsv",
       "num_samples": 252,
       "num_columns": 30,
       "organisms": [
@@ -4505,8 +4478,8 @@
       "file": "PXD008840.sdrf.tsv",
       "filename": "PXD008840.sdrf.tsv",
       "path": "datasets/PXD008840/PXD008840.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008840/PXD008840.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008840/PXD008840.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008840/PXD008840.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008840/PXD008840.sdrf.tsv",
       "num_samples": 1016,
       "num_columns": 34,
       "organisms": [
@@ -4531,20 +4504,20 @@
       "file": "PXD008841.sdrf.tsv",
       "filename": "PXD008841.sdrf.tsv",
       "path": "datasets/PXD008841/PXD008841.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008841/PXD008841.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008841/PXD008841.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008841/PXD008841.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008841/PXD008841.sdrf.tsv",
       "num_samples": 3600,
       "num_columns": 31,
       "organisms": [
         "Homo Sapiens"
       ],
       "diseases": [
+        "breast cancer",
+        "basal-like breast carcinoma",
         "luminal A breast carcinoma",
         "luminal B breast carcinoma",
-        "HER2 Positive Breast Carcinoma",
         "Normal Breast-Like Subtype of Breast Carcinoma",
-        "basal-like breast carcinoma",
-        "breast cancer"
+        "HER2 Positive Breast Carcinoma"
       ],
       "instruments": [
         "Q Exactive"
@@ -4562,8 +4535,8 @@
       "file": "PXD008921.sdrf.tsv",
       "filename": "PXD008921.sdrf.tsv",
       "path": "datasets/PXD008921/PXD008921.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008921/PXD008921.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008921/PXD008921.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008921/PXD008921.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008921/PXD008921.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 35,
       "organisms": [
@@ -4586,18 +4559,18 @@
       "file": "PXD008934.sdrf.tsv",
       "filename": "PXD008934.sdrf.tsv",
       "path": "datasets/PXD008934/PXD008934.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008934/PXD008934.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008934/PXD008934.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008934/PXD008934.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008934/PXD008934.sdrf.tsv",
       "num_samples": 34,
       "num_columns": 29,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "dilated cardiomyopathy",
         "ischemic cardiomyopathy",
-        "compensated hypertrophy",
-        "cardiac hypertrophy"
+        "dilated cardiomyopathy",
+        "cardiac hypertrophy",
+        "compensated hypertrophy"
       ],
       "instruments": [
         "Q Exactive"
@@ -4615,8 +4588,8 @@
       "file": "PXD009157.sdrf.tsv",
       "filename": "PXD009157.sdrf.tsv",
       "path": "datasets/PXD009157/PXD009157.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009157/PXD009157.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009157/PXD009157.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009157/PXD009157.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009157/PXD009157.sdrf.tsv",
       "num_samples": 66,
       "num_columns": 29,
       "organisms": [
@@ -4639,8 +4612,8 @@
       "file": "PXD009203.sdrf.tsv",
       "filename": "PXD009203.sdrf.tsv",
       "path": "datasets/PXD009203/PXD009203.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009203/PXD009203.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009203/PXD009203.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009203/PXD009203.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009203/PXD009203.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 29,
       "organisms": [
@@ -4666,8 +4639,8 @@
       "file": "PXD009465.sdrf.tsv",
       "filename": "PXD009465.sdrf.tsv",
       "path": "datasets/PXD009465/PXD009465.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009465/PXD009465.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009465/PXD009465.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009465/PXD009465.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009465/PXD009465.sdrf.tsv",
       "num_samples": 60,
       "num_columns": 29,
       "organisms": [
@@ -4690,8 +4663,8 @@
       "file": "PXD009602.sdrf.tsv",
       "filename": "PXD009602.sdrf.tsv",
       "path": "datasets/PXD009602/PXD009602.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009602/PXD009602.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009602/PXD009602.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009602/PXD009602.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009602/PXD009602.sdrf.tsv",
       "num_samples": 528,
       "num_columns": 33,
       "organisms": [
@@ -4716,8 +4689,8 @@
       "file": "PXD009623-dda.sdrf.tsv",
       "filename": "PXD009623-dda.sdrf.tsv",
       "path": "datasets/PXD009623/PXD009623-dda.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009623/PXD009623-dda.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009623/PXD009623-dda.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009623/PXD009623-dda.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009623/PXD009623-dda.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 27,
       "organisms": [
@@ -4740,8 +4713,8 @@
       "file": "PXD009623-dia.sdrf.tsv",
       "filename": "PXD009623-dia.sdrf.tsv",
       "path": "datasets/PXD009623/PXD009623-dia.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009623/PXD009623-dia.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009623/PXD009623-dia.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009623/PXD009623-dia.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009623/PXD009623-dia.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 27,
       "organisms": [
@@ -4764,8 +4737,8 @@
       "file": "PXD009630.sdrf.tsv",
       "filename": "PXD009630.sdrf.tsv",
       "path": "datasets/PXD009630/PXD009630.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009630/PXD009630.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009630/PXD009630.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009630/PXD009630.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009630/PXD009630.sdrf.tsv",
       "num_samples": 111,
       "num_columns": 29,
       "organisms": [
@@ -4774,15 +4747,15 @@
       "diseases": [
         "other",
         "superficial spreading melanoma",
-        "acral lentiginous melanoma",
-        "unknown",
-        "lentigo maligna melanoma",
         "mucosal",
-        "nodular melanoma"
+        "acral lentiginous melanoma",
+        "nodular melanoma",
+        "unknown",
+        "lentigo maligna melanoma"
       ],
       "instruments": [
-        "Q Exactive Plus",
-        "Q Exactive"
+        "Q Exactive",
+        "Q Exactive Plus"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -4797,8 +4770,8 @@
       "file": "PXD009815.sdrf.tsv",
       "filename": "PXD009815.sdrf.tsv",
       "path": "datasets/PXD009815/PXD009815.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009815/PXD009815.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009815/PXD009815.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009815/PXD009815.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009815/PXD009815.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 27,
       "organisms": [
@@ -4821,8 +4794,8 @@
       "file": "PXD009909.sdrf.tsv",
       "filename": "PXD009909.sdrf.tsv",
       "path": "datasets/PXD009909/PXD009909.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009909/PXD009909.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009909/PXD009909.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009909/PXD009909.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009909/PXD009909.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 27,
       "organisms": [
@@ -4845,8 +4818,8 @@
       "file": "PXD010154.sdrf.tsv",
       "filename": "PXD010154.sdrf.tsv",
       "path": "datasets/PXD010154/PXD010154.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010154/PXD010154.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010154/PXD010154.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010154/PXD010154.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010154/PXD010154.sdrf.tsv",
       "num_samples": 1800,
       "num_columns": 32,
       "organisms": [
@@ -4855,8 +4828,8 @@
       "diseases": [],
       "instruments": [
         "Orbitrap Fusion Lumos",
-        "Q Exactive Plus",
-        "Q Exactive HF"
+        "Q Exactive HF",
+        "Q Exactive Plus"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -4871,8 +4844,8 @@
       "file": "PXD010271.sdrf.tsv",
       "filename": "PXD010271.sdrf.tsv",
       "path": "datasets/PXD010271/PXD010271.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010271/PXD010271.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010271/PXD010271.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010271/PXD010271.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010271/PXD010271.sdrf.tsv",
       "num_samples": 252,
       "num_columns": 30,
       "organisms": [
@@ -4882,8 +4855,8 @@
         "Disease"
       ],
       "instruments": [
-        "LTQ Orbitrap Velos",
-        "Q Exactive"
+        "Q Exactive",
+        "LTQ Orbitrap Velos"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -4898,8 +4871,8 @@
       "file": "PXD010357.sdrf.tsv",
       "filename": "PXD010357.sdrf.tsv",
       "path": "datasets/PXD010357/PXD010357.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010357/PXD010357.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010357/PXD010357.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010357/PXD010357.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010357/PXD010357.sdrf.tsv",
       "num_samples": 116,
       "num_columns": 27,
       "organisms": [
@@ -4924,22 +4897,22 @@
       "file": "PXD010371.sdrf.tsv",
       "filename": "PXD010371.sdrf.tsv",
       "path": "datasets/PXD010371/PXD010371.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010371/PXD010371.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010371/PXD010371.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010371/PXD010371.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010371/PXD010371.sdrf.tsv",
       "num_samples": 77,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
+        "Gastric Carcinoma",
+        "Healthy control",
         "Ulcerative Colitis active stage",
         "Irritable Bowel Syndrome",
-        "Healthy control",
-        "Colon Adenoma",
-        "Ulcerative Colitis remission stage",
         "'Crohn''s Disease Irritable Bowel Syndrome'",
-        "'Crohn''s Disease'",
-        "Gastric Carcinoma"
+        "Ulcerative Colitis remission stage",
+        "Colon Adenoma",
+        "'Crohn''s Disease'"
       ],
       "instruments": [
         "Q Exactive HF"
@@ -4957,8 +4930,8 @@
       "file": "PXD010429.sdrf.tsv",
       "filename": "PXD010429.sdrf.tsv",
       "path": "datasets/PXD010429/PXD010429.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010429/PXD010429.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010429/PXD010429.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010429/PXD010429.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010429/PXD010429.sdrf.tsv",
       "num_samples": 4176,
       "num_columns": 34,
       "organisms": [
@@ -4983,8 +4956,8 @@
       "file": "PXD010595.sdrf.tsv",
       "filename": "PXD010595.sdrf.tsv",
       "path": "datasets/PXD010595/PXD010595.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010595/PXD010595.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010595/PXD010595.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010595/PXD010595.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010595/PXD010595.sdrf.tsv",
       "num_samples": 888,
       "num_columns": 40,
       "organisms": [
@@ -5007,8 +4980,8 @@
       "file": "PXD010603.sdrf.tsv",
       "filename": "PXD010603.sdrf.tsv",
       "path": "datasets/PXD010603/PXD010603.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010603/PXD010603.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010603/PXD010603.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010603/PXD010603.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010603/PXD010603.sdrf.tsv",
       "num_samples": 311,
       "num_columns": 35,
       "organisms": [
@@ -5033,8 +5006,8 @@
       "file": "PXD010698.sdrf.tsv",
       "filename": "PXD010698.sdrf.tsv",
       "path": "datasets/PXD010698/PXD010698.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010698/PXD010698.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010698/PXD010698.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010698/PXD010698.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010698/PXD010698.sdrf.tsv",
       "num_samples": 5,
       "num_columns": 27,
       "organisms": [
@@ -5059,8 +5032,8 @@
       "file": "PXD010705.sdrf.tsv",
       "filename": "PXD010705.sdrf.tsv",
       "path": "datasets/PXD010705/PXD010705.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010705/PXD010705.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010705/PXD010705.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010705/PXD010705.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010705/PXD010705.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 26,
       "organisms": [
@@ -5085,8 +5058,8 @@
       "file": "PXD010708.sdrf.tsv",
       "filename": "PXD010708.sdrf.tsv",
       "path": "datasets/PXD010708/PXD010708.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010708/PXD010708.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010708/PXD010708.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010708/PXD010708.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010708/PXD010708.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 27,
       "organisms": [
@@ -5111,8 +5084,8 @@
       "file": "PXD010981.sdrf.tsv",
       "filename": "PXD010981.sdrf.tsv",
       "path": "datasets/PXD010981/PXD010981.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010981/PXD010981.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010981/PXD010981.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010981/PXD010981.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010981/PXD010981.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 36,
       "organisms": [
@@ -5135,8 +5108,8 @@
       "file": "PXD011023.sdrf.tsv",
       "filename": "PXD011023.sdrf.tsv",
       "path": "datasets/PXD011023/PXD011023.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011023/PXD011023.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011023/PXD011023.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011023/PXD011023.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011023/PXD011023.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 36,
       "organisms": [
@@ -5159,8 +5132,8 @@
       "file": "PXD011050.sdrf.tsv",
       "filename": "PXD011050.sdrf.tsv",
       "path": "datasets/PXD011050/PXD011050.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011050/PXD011050.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011050/PXD011050.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011050/PXD011050.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011050/PXD011050.sdrf.tsv",
       "num_samples": 16,
       "num_columns": 24,
       "organisms": [
@@ -5183,8 +5156,8 @@
       "file": "PXD011153.sdrf.tsv",
       "filename": "PXD011153.sdrf.tsv",
       "path": "datasets/PXD011153/PXD011153.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011153/PXD011153.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011153/PXD011153.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011153/PXD011153.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011153/PXD011153.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 26,
       "organisms": [
@@ -5209,8 +5182,8 @@
       "file": "PXD011175.sdrf.tsv",
       "filename": "PXD011175.sdrf.tsv",
       "path": "datasets/PXD011175/PXD011175.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011175/PXD011175.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011175/PXD011175.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011175/PXD011175.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011175/PXD011175.sdrf.tsv",
       "num_samples": 28,
       "num_columns": 37,
       "organisms": [
@@ -5235,8 +5208,8 @@
       "file": "PXD011799.sdrf.tsv",
       "filename": "PXD011799.sdrf.tsv",
       "path": "datasets/PXD011799/PXD011799.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011799/PXD011799.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011799/PXD011799.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011799/PXD011799.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011799/PXD011799.sdrf.tsv",
       "num_samples": 480,
       "num_columns": 35,
       "organisms": [
@@ -5261,17 +5234,17 @@
       "file": "PXD011839.sdrf.tsv",
       "filename": "PXD011839.sdrf.tsv",
       "path": "datasets/PXD011839/PXD011839.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011839/PXD011839.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011839/PXD011839.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011839/PXD011839.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011839/PXD011839.sdrf.tsv",
       "num_samples": 399,
       "num_columns": 38,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
+        "cirrhosis of liver",
         "type II diabetes mellitus",
-        "non-alcoholic fatty liver disease",
-        "cirrhosis of liver"
+        "non-alcoholic fatty liver disease"
       ],
       "instruments": [
         "Q Exactive HF-X"
@@ -5289,8 +5262,8 @@
       "file": "PXD011967.sdrf.tsv",
       "filename": "PXD011967.sdrf.tsv",
       "path": "datasets/PXD011967/PXD011967.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011967/PXD011967.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011967/PXD011967.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011967/PXD011967.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011967/PXD011967.sdrf.tsv",
       "num_samples": 2316,
       "num_columns": 31,
       "organisms": [
@@ -5313,16 +5286,16 @@
       "file": "PXD012131.sdrf.tsv",
       "filename": "PXD012131.sdrf.tsv",
       "path": "datasets/PXD012131/PXD012131.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012131/PXD012131.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012131/PXD012131.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012131/PXD012131.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012131/PXD012131.sdrf.tsv",
       "num_samples": 326,
       "num_columns": 37,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "Alzheimer's disease (stage III)",
-        "Alzheimer's disease (stage VI)"
+        "Alzheimer's disease (stage VI)",
+        "Alzheimer's disease (stage III)"
       ],
       "instruments": [
         "Orbitrap Fusion Lumos"
@@ -5340,8 +5313,8 @@
       "file": "PXD012143.sdrf.tsv",
       "filename": "PXD012143.sdrf.tsv",
       "path": "datasets/PXD012143/PXD012143.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012143/PXD012143.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012143/PXD012143.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012143/PXD012143.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012143/PXD012143.sdrf.tsv",
       "num_samples": 320,
       "num_columns": 30,
       "organisms": [
@@ -5364,8 +5337,8 @@
       "file": "PXD012203.sdrf.tsv",
       "filename": "PXD012203.sdrf.tsv",
       "path": "datasets/PXD012203/PXD012203.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012203/PXD012203.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012203/PXD012203.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012203/PXD012203.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012203/PXD012203.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 31,
       "organisms": [
@@ -5373,8 +5346,8 @@
       ],
       "diseases": [
         "Non-demented control",
-        "Alzheimer's diseasemedial",
-        "Alzheimer's disease"
+        "Alzheimer's disease",
+        "Alzheimer's diseasemedial"
       ],
       "instruments": [
         "Q Exactive"
@@ -5392,8 +5365,8 @@
       "file": "PXD012243.sdrf.tsv",
       "filename": "PXD012243.sdrf.tsv",
       "path": "datasets/PXD012243/PXD012243.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012243/PXD012243.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012243/PXD012243.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012243/PXD012243.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012243/PXD012243.sdrf.tsv",
       "num_samples": 128,
       "num_columns": 37,
       "organisms": [
@@ -5418,8 +5391,8 @@
       "file": "PXD012255.sdrf.tsv",
       "filename": "PXD012255.sdrf.tsv",
       "path": "datasets/PXD012255/PXD012255.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012255/PXD012255.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012255/PXD012255.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012255/PXD012255.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012255/PXD012255.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 32,
       "organisms": [
@@ -5444,8 +5417,8 @@
       "file": "PXD012277.sdrf.tsv",
       "filename": "PXD012277.sdrf.tsv",
       "path": "datasets/PXD012277/PXD012277.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012277/PXD012277.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012277/PXD012277.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012277/PXD012277.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012277/PXD012277.sdrf.tsv",
       "num_samples": 42,
       "num_columns": 37,
       "organisms": [
@@ -5468,8 +5441,8 @@
       "file": "PXD012307.sdrf.tsv",
       "filename": "PXD012307.sdrf.tsv",
       "path": "datasets/PXD012307/PXD012307.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012307/PXD012307.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012307/PXD012307.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012307/PXD012307.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012307/PXD012307.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 28,
       "organisms": [
@@ -5492,8 +5465,8 @@
       "file": "PXD012431.sdrf.tsv",
       "filename": "PXD012431.sdrf.tsv",
       "path": "datasets/PXD012431/PXD012431.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012431/PXD012431.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012431/PXD012431.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012431/PXD012431.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012431/PXD012431.sdrf.tsv",
       "num_samples": 69,
       "num_columns": 31,
       "organisms": [
@@ -5518,8 +5491,8 @@
       "file": "PXD012593-rat.sdrf.tsv",
       "filename": "PXD012593-rat.sdrf.tsv",
       "path": "datasets/PXD012593/PXD012593-rat.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012593/PXD012593-rat.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012593/PXD012593-rat.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012593/PXD012593-rat.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012593/PXD012593-rat.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 22,
       "organisms": [
@@ -5542,8 +5515,8 @@
       "file": "PXD012593-srm.sdrf.tsv",
       "filename": "PXD012593-srm.sdrf.tsv",
       "path": "datasets/PXD012593/PXD012593-srm.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012593/PXD012593-srm.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012593/PXD012593-srm.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012593/PXD012593-srm.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012593/PXD012593-srm.sdrf.tsv",
       "num_samples": 55,
       "num_columns": 26,
       "organisms": [
@@ -5551,8 +5524,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Q Exactive Plus",
-        "TSQ Quantiva"
+        "TSQ Quantiva",
+        "Q Exactive Plus"
       ],
       "acquisition_methods": [
         "selected reaction monitoring"
@@ -5567,8 +5540,8 @@
       "file": "PXD012611.sdrf.tsv",
       "filename": "PXD012611.sdrf.tsv",
       "path": "datasets/PXD012611/PXD012611.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012611/PXD012611.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012611/PXD012611.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012611/PXD012611.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012611/PXD012611.sdrf.tsv",
       "num_samples": 34,
       "num_columns": 34,
       "organisms": [
@@ -5591,8 +5564,8 @@
       "file": "PXD012755.sdrf.tsv",
       "filename": "PXD012755.sdrf.tsv",
       "path": "datasets/PXD012755/PXD012755.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012755/PXD012755.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012755/PXD012755.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012755/PXD012755.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012755/PXD012755.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 29,
       "organisms": [
@@ -5618,8 +5591,8 @@
       "file": "PXD012764.sdrf.tsv",
       "filename": "PXD012764.sdrf.tsv",
       "path": "datasets/PXD012764/PXD012764.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012764/PXD012764.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012764/PXD012764.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012764/PXD012764.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012764/PXD012764.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 26,
       "organisms": [
@@ -5642,8 +5615,8 @@
       "file": "PXD012923.sdrf.tsv",
       "filename": "PXD012923.sdrf.tsv",
       "path": "datasets/PXD012923/PXD012923.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012923/PXD012923.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012923/PXD012923.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012923/PXD012923.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012923/PXD012923.sdrf.tsv",
       "num_samples": 78,
       "num_columns": 37,
       "organisms": [
@@ -5668,8 +5641,8 @@
       "file": "PXD012986.sdrf.tsv",
       "filename": "PXD012986.sdrf.tsv",
       "path": "datasets/PXD012986/PXD012986.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012986/PXD012986.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012986/PXD012986.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012986/PXD012986.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012986/PXD012986.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 43,
       "organisms": [
@@ -5692,16 +5665,16 @@
       "file": "PXD013234.sdrf.tsv",
       "filename": "PXD013234.sdrf.tsv",
       "path": "datasets/PXD013234/PXD013234.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013234/PXD013234.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013234/PXD013234.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013234/PXD013234.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013234/PXD013234.sdrf.tsv",
       "num_samples": 54,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "uninfected",
-        "polycythemia vera"
+        "polycythemia vera",
+        "uninfected"
       ],
       "instruments": [
         "Q Exactive HF-X"
@@ -5719,8 +5692,8 @@
       "file": "PXD013273.sdrf.tsv",
       "filename": "PXD013273.sdrf.tsv",
       "path": "datasets/PXD013273/PXD013273.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013273/PXD013273.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013273/PXD013273.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013273/PXD013273.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013273/PXD013273.sdrf.tsv",
       "num_samples": 28,
       "num_columns": 30,
       "organisms": [
@@ -5743,8 +5716,8 @@
       "file": "PXD013523.sdrf.tsv",
       "filename": "PXD013523.sdrf.tsv",
       "path": "datasets/PXD013523/PXD013523.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013523/PXD013523.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013523/PXD013523.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013523/PXD013523.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013523/PXD013523.sdrf.tsv",
       "num_samples": 198,
       "num_columns": 35,
       "organisms": [
@@ -5769,8 +5742,8 @@
       "file": "PXD013610.sdrf.tsv",
       "filename": "PXD013610.sdrf.tsv",
       "path": "datasets/PXD013610/PXD013610.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013610/PXD013610.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013610/PXD013610.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013610/PXD013610.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013610/PXD013610.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 31,
       "organisms": [
@@ -5793,8 +5766,8 @@
       "file": "PXD013737.sdrf.tsv",
       "filename": "PXD013737.sdrf.tsv",
       "path": "datasets/PXD013737/PXD013737.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013737/PXD013737.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013737/PXD013737.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013737/PXD013737.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013737/PXD013737.sdrf.tsv",
       "num_samples": 96,
       "num_columns": 35,
       "organisms": [
@@ -5817,16 +5790,16 @@
       "file": "PXD013753.sdrf.tsv",
       "filename": "PXD013753.sdrf.tsv",
       "path": "datasets/PXD013753/PXD013753.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013753/PXD013753.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013753/PXD013753.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013753/PXD013753.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013753/PXD013753.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 37,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "Control",
-        "Alzheimer's Disease"
+        "Alzheimer's Disease",
+        "Control"
       ],
       "instruments": [
         "Q Exactive HF"
@@ -5844,8 +5817,8 @@
       "file": "PXD013765.sdrf.tsv",
       "filename": "PXD013765.sdrf.tsv",
       "path": "datasets/PXD013765/PXD013765.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013765/PXD013765.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013765/PXD013765.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013765/PXD013765.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013765/PXD013765.sdrf.tsv",
       "num_samples": 144,
       "num_columns": 34,
       "organisms": [
@@ -5870,8 +5843,8 @@
       "file": "PXD013868.sdrf.tsv",
       "filename": "PXD013868.sdrf.tsv",
       "path": "datasets/PXD013868/PXD013868.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013868/PXD013868.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013868/PXD013868.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013868/PXD013868.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013868/PXD013868.sdrf.tsv",
       "num_samples": 1560,
       "num_columns": 30,
       "organisms": [
@@ -5894,8 +5867,8 @@
       "file": "PXD013923.sdrf.tsv",
       "filename": "PXD013923.sdrf.tsv",
       "path": "datasets/PXD013923/PXD013923.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013923/PXD013923.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013923/PXD013923.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013923/PXD013923.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013923/PXD013923.sdrf.tsv",
       "num_samples": 372,
       "num_columns": 39,
       "organisms": [
@@ -5920,8 +5893,8 @@
       "file": "PXD014058.sdrf.tsv",
       "filename": "PXD014058.sdrf.tsv",
       "path": "datasets/PXD014058/PXD014058.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014058/PXD014058.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014058/PXD014058.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014058/PXD014058.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014058/PXD014058.sdrf.tsv",
       "num_samples": 323,
       "num_columns": 31,
       "organisms": [
@@ -5930,8 +5903,8 @@
       "diseases": [
         "Hepatoblastoma",
         "Colorectal cancer",
-        "gastric carcinoma",
-        "epithelial cervix carcinoma"
+        "epithelial cervix carcinoma",
+        "gastric carcinoma"
       ],
       "instruments": [
         "Orbitrap Fusion Lumos"
@@ -5949,8 +5922,8 @@
       "file": "PXD014145.sdrf.tsv",
       "filename": "PXD014145.sdrf.tsv",
       "path": "datasets/PXD014145/PXD014145.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014145/PXD014145.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014145/PXD014145.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014145/PXD014145.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014145/PXD014145.sdrf.tsv",
       "num_samples": 132,
       "num_columns": 33,
       "organisms": [
@@ -5975,8 +5948,8 @@
       "file": "PXD14458.sdrf.tsv",
       "filename": "PXD14458.sdrf.tsv",
       "path": "datasets/PXD014458/PXD14458.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014458/PXD14458.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014458/PXD14458.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014458/PXD14458.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014458/PXD14458.sdrf.tsv",
       "num_samples": 44,
       "num_columns": 29,
       "organisms": [
@@ -6002,8 +5975,8 @@
       "file": "PXD014502.sdrf.tsv",
       "filename": "PXD014502.sdrf.tsv",
       "path": "datasets/PXD014502/PXD014502.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014502/PXD014502.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014502/PXD014502.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014502/PXD014502.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014502/PXD014502.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 23,
       "organisms": [
@@ -6026,8 +5999,8 @@
       "file": "PXD014525-dda.sdrf.tsv",
       "filename": "PXD014525-dda.sdrf.tsv",
       "path": "datasets/PXD014525/PXD014525-dda.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014525/PXD014525-dda.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014525/PXD014525-dda.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014525/PXD014525-dda.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014525/PXD014525-dda.sdrf.tsv",
       "num_samples": 224,
       "num_columns": 38,
       "organisms": [
@@ -6053,8 +6026,8 @@
       "file": "PXD014525-dia.sdrf.tsv",
       "filename": "PXD014525-dia.sdrf.tsv",
       "path": "datasets/PXD014525/PXD014525-dia.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014525/PXD014525-dia.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014525/PXD014525-dia.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014525/PXD014525-dia.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014525/PXD014525-dia.sdrf.tsv",
       "num_samples": 427,
       "num_columns": 35,
       "organisms": [
@@ -6080,8 +6053,8 @@
       "file": "PXD014528.sdrf.tsv",
       "filename": "PXD014528.sdrf.tsv",
       "path": "datasets/PXD014528/PXD014528.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014528/PXD014528.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014528/PXD014528.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014528/PXD014528.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014528/PXD014528.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 29,
       "organisms": [
@@ -6104,8 +6077,8 @@
       "file": "PXD014557.sdrf.tsv",
       "filename": "PXD014557.sdrf.tsv",
       "path": "datasets/PXD014557/PXD014557.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014557/PXD014557.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014557/PXD014557.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014557/PXD014557.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014557/PXD014557.sdrf.tsv",
       "num_samples": 400,
       "num_columns": 34,
       "organisms": [
@@ -6130,8 +6103,8 @@
       "file": "PXD014565.sdrf.tsv",
       "filename": "PXD014565.sdrf.tsv",
       "path": "datasets/PXD014565/PXD014565.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014565/PXD014565.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014565/PXD014565.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014565/PXD014565.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014565/PXD014565.sdrf.tsv",
       "num_samples": 80,
       "num_columns": 33,
       "organisms": [
@@ -6156,8 +6129,8 @@
       "file": "PXD015093-LFQ.sdrf.tsv",
       "filename": "PXD015093-LFQ.sdrf.tsv",
       "path": "datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
       "num_samples": 148,
       "num_columns": 29,
       "organisms": [
@@ -6180,8 +6153,8 @@
       "file": "PXD015093-TMT.sdrf.tsv",
       "filename": "PXD015093-TMT.sdrf.tsv",
       "path": "datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
       "num_samples": 1380,
       "num_columns": 32,
       "organisms": [
@@ -6204,8 +6177,8 @@
       "file": "PXD015270.sdrf.tsv",
       "filename": "PXD015270.sdrf.tsv",
       "path": "datasets/PXD015270/PXD015270.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015270/PXD015270.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015270/PXD015270.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015270/PXD015270.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015270/PXD015270.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 33,
       "organisms": [
@@ -6231,8 +6204,8 @@
       "file": "PXD015578.sdrf.tsv",
       "filename": "PXD015578.sdrf.tsv",
       "path": "datasets/PXD015578/PXD015578.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015578/PXD015578.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015578/PXD015578.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015578/PXD015578.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015578/PXD015578.sdrf.tsv",
       "num_samples": 34,
       "num_columns": 32,
       "organisms": [
@@ -6255,8 +6228,8 @@
       "file": "PXD015744.sdrf.tsv",
       "filename": "PXD015744.sdrf.tsv",
       "path": "datasets/PXD015744/PXD015744.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015744/PXD015744.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015744/PXD015744.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015744/PXD015744.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015744/PXD015744.sdrf.tsv",
       "num_samples": 100,
       "num_columns": 32,
       "organisms": [
@@ -6281,19 +6254,19 @@
       "file": "PXD015833-Exp1.sdrf.tsv",
       "filename": "PXD015833-Exp1.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
       "num_samples": 360,
       "num_columns": 32,
       "organisms": [
         "Homo sapiens",
-        "plasmodium knowlesi",
-        "plasmodium falciparum"
+        "plasmodium falciparum",
+        "plasmodium knowlesi"
       ],
       "diseases": [],
       "instruments": [
-        "Orbitrap Fusion Lumos",
-        "Q Exactive"
+        "Q Exactive",
+        "Orbitrap Fusion Lumos"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -6308,8 +6281,8 @@
       "file": "PXD015833-Exp2.sdrf.tsv",
       "filename": "PXD015833-Exp2.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
       "num_samples": 120,
       "num_columns": 33,
       "organisms": [
@@ -6333,8 +6306,8 @@
       "file": "PXD015833-Exp3.sdrf.tsv",
       "filename": "PXD015833-Exp3.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 31,
       "organisms": [
@@ -6357,13 +6330,13 @@
       "file": "PXD015833-Exp4.sdrf.tsv",
       "filename": "PXD015833-Exp4.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 31,
       "organisms": [
-        "plasmodium knowlesi",
-        "plasmodium falciparum"
+        "plasmodium falciparum",
+        "plasmodium knowlesi"
       ],
       "diseases": [],
       "instruments": [
@@ -6382,13 +6355,13 @@
       "file": "PXD015833-Exp5.sdrf.tsv",
       "filename": "PXD015833-Exp5.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 31,
       "organisms": [
-        "plasmodium knowlesi",
-        "plasmodium falciparum"
+        "plasmodium falciparum",
+        "plasmodium knowlesi"
       ],
       "diseases": [],
       "instruments": [
@@ -6407,13 +6380,13 @@
       "file": "PXD015833-Exp6.sdrf.tsv",
       "filename": "PXD015833-Exp6.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 31,
       "organisms": [
-        "plasmodium knowlesi",
-        "plasmodium falciparum"
+        "plasmodium falciparum",
+        "plasmodium knowlesi"
       ],
       "diseases": [],
       "instruments": [
@@ -6432,16 +6405,16 @@
       "file": "PXD015957.sdrf.tsv",
       "filename": "PXD015957.sdrf.tsv",
       "path": "datasets/PXD015957/PXD015957.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015957/PXD015957.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015957/PXD015957.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015957/PXD015957.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015957/PXD015957.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 36,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "metastatic melanoma tumor",
-        "malignant melanoma"
+        "malignant melanoma",
+        "metastatic melanoma tumor"
       ],
       "instruments": [
         " Q Exactive Plus"
@@ -6459,8 +6432,8 @@
       "file": "PXD016001.sdrf.tsv",
       "filename": "PXD016001.sdrf.tsv",
       "path": "datasets/PXD016001/PXD016001.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016001/PXD016001.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016001/PXD016001.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016001/PXD016001.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016001/PXD016001.sdrf.tsv",
       "num_samples": 61,
       "num_columns": 32,
       "organisms": [
@@ -6483,8 +6456,8 @@
       "file": "PXD016002.sdrf.tsv",
       "filename": "PXD016002.sdrf.tsv",
       "path": "datasets/PXD016002/PXD016002.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016002/PXD016002.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016002/PXD016002.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016002/PXD016002.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016002/PXD016002.sdrf.tsv",
       "num_samples": 1008,
       "num_columns": 34,
       "organisms": [
@@ -6509,8 +6482,8 @@
       "file": "PXD016074.sdrf.tsv",
       "filename": "PXD016074.sdrf.tsv",
       "path": "datasets/PXD016074/PXD016074.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016074/PXD016074.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016074/PXD016074.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016074/PXD016074.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016074/PXD016074.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 33,
       "organisms": [
@@ -6533,8 +6506,8 @@
       "file": "PXD016669.sdrf.tsv",
       "filename": "PXD016669.sdrf.tsv",
       "path": "datasets/PXD016669/PXD016669.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016669/PXD016669.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016669/PXD016669.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016669/PXD016669.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016669/PXD016669.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 34,
       "organisms": [
@@ -6542,8 +6515,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Orbitrap Velos Pro",
-        "Q Exactive Plus"
+        "Q Exactive Plus",
+        "Orbitrap Velos Pro"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -6558,8 +6531,8 @@
       "file": "PXD016772.sdrf.tsv",
       "filename": "PXD016772.sdrf.tsv",
       "path": "datasets/PXD016772/PXD016772.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016772/PXD016772.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016772/PXD016772.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016772/PXD016772.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016772/PXD016772.sdrf.tsv",
       "num_samples": 22,
       "num_columns": 30,
       "organisms": [
@@ -6582,8 +6555,8 @@
       "file": "PXD016837.sdrf.tsv",
       "filename": "PXD016837.sdrf.tsv",
       "path": "datasets/PXD016837/PXD016837.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016837/PXD016837.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016837/PXD016837.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016837/PXD016837.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016837/PXD016837.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 32,
       "organisms": [
@@ -6608,19 +6581,19 @@
       "file": "PXD017035.sdrf.tsv",
       "filename": "PXD017035.sdrf.tsv",
       "path": "datasets/PXD017035/PXD017035.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017035/PXD017035.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017035/PXD017035.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017035/PXD017035.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017035/PXD017035.sdrf.tsv",
       "num_samples": 720,
       "num_columns": 30,
       "organisms": [
-        "clostridium",
-        "Blautia producta",
-        "Anaerostipes caccae",
         "lactobacillus",
-        "Escherichia coli K-12",
-        "Clostridium butyricum",
         "Bifidobacterium longum",
-        "Bacteroides thetaiotaomicron"
+        "Anaerostipes caccae",
+        "Bacteroides thetaiotaomicron",
+        "clostridium",
+        "Clostridium butyricum",
+        "Escherichia coli K-12",
+        "Blautia producta"
       ],
       "diseases": [],
       "instruments": [
@@ -6639,8 +6612,8 @@
       "file": "PXD017201.sdrf.tsv",
       "filename": "PXD017201.sdrf.tsv",
       "path": "datasets/PXD017201/PXD017201.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017201/PXD017201.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017201/PXD017201.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017201/PXD017201.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017201/PXD017201.sdrf.tsv",
       "num_samples": 3600,
       "num_columns": 39,
       "organisms": [
@@ -6665,8 +6638,8 @@
       "file": "PXD017291-mixed-label.sdrf.tsv",
       "filename": "PXD017291-mixed-label.sdrf.tsv",
       "path": "datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
       "num_samples": 1584,
       "num_columns": 40,
       "organisms": [
@@ -6692,8 +6665,8 @@
       "file": "PXD017291-tmt.sdrf.tsv",
       "filename": "PXD017291-tmt.sdrf.tsv",
       "path": "datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
       "num_samples": 600,
       "num_columns": 38,
       "organisms": [
@@ -6718,8 +6691,8 @@
       "file": "PXD017602.sdrf.tsv",
       "filename": "PXD017602.sdrf.tsv",
       "path": "datasets/PXD017602/PXD017602.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017602/PXD017602.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017602/PXD017602.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017602/PXD017602.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017602/PXD017602.sdrf.tsv",
       "num_samples": 64,
       "num_columns": 18,
       "organisms": [
@@ -6744,8 +6717,8 @@
       "file": "PXD017618.sdrf.tsv",
       "filename": "PXD017618.sdrf.tsv",
       "path": "datasets/PXD017618/PXD017618.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017618/PXD017618.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017618/PXD017618.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017618/PXD017618.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017618/PXD017618.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 31,
       "organisms": [
@@ -6769,8 +6742,8 @@
       "file": "PXD017710-silac.sdrf.tsv",
       "filename": "PXD017710-silac.sdrf.tsv",
       "path": "datasets/PXD017710/PXD017710-silac.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017710/PXD017710-silac.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017710/PXD017710-silac.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017710/PXD017710-silac.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017710/PXD017710-silac.sdrf.tsv",
       "num_samples": 264,
       "num_columns": 38,
       "organisms": [
@@ -6796,8 +6769,8 @@
       "file": "PXD017710-tmt.sdrf.tsv",
       "filename": "PXD017710-tmt.sdrf.tsv",
       "path": "datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
       "num_samples": 216,
       "num_columns": 35,
       "organisms": [
@@ -6822,8 +6795,8 @@
       "file": "PXD018117.sdrf.tsv",
       "filename": "PXD018117.sdrf.tsv",
       "path": "datasets/PXD018117/PXD018117.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018117/PXD018117.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018117/PXD018117.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018117/PXD018117.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018117/PXD018117.sdrf.tsv",
       "num_samples": 98,
       "num_columns": 33,
       "organisms": [
@@ -6846,8 +6819,8 @@
       "file": "PXD018241-phosphoproteomics.sdrf.tsv",
       "filename": "PXD018241-phosphoproteomics.sdrf.tsv",
       "path": "datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
       "num_samples": 2,
       "num_columns": 32,
       "organisms": [
@@ -6870,8 +6843,8 @@
       "file": "PXD018241.sdrf.tsv",
       "filename": "PXD018241.sdrf.tsv",
       "path": "datasets/PXD018241/PXD018241.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018241/PXD018241.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018241/PXD018241.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018241/PXD018241.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018241/PXD018241.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 31,
       "organisms": [
@@ -6894,8 +6867,8 @@
       "file": "PXD018357.sdrf.tsv",
       "filename": "PXD018357.sdrf.tsv",
       "path": "datasets/PXD018357/PXD018357.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018357/PXD018357.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018357/PXD018357.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018357/PXD018357.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018357/PXD018357.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 33,
       "organisms": [
@@ -6921,8 +6894,8 @@
       "file": "PXD018581.sdrf.tsv",
       "filename": "PXD018581.sdrf.tsv",
       "path": "datasets/PXD018581/PXD018581.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018581/PXD018581.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018581/PXD018581.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018581/PXD018581.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018581/PXD018581.sdrf.tsv",
       "num_samples": 481,
       "num_columns": 37,
       "organisms": [
@@ -6947,8 +6920,8 @@
       "file": "PXD018594.sdrf.tsv",
       "filename": "PXD018594.sdrf.tsv",
       "path": "datasets/PXD018594/PXD018594.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018594/PXD018594.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018594/PXD018594.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018594/PXD018594.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018594/PXD018594.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 34,
       "organisms": [
@@ -6971,8 +6944,8 @@
       "file": "PXD018678-dda.sdrf.tsv",
       "filename": "PXD018678-dda.sdrf.tsv",
       "path": "datasets/PXD018678/PXD018678-dda.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018678/PXD018678-dda.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018678/PXD018678-dda.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018678/PXD018678-dda.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018678/PXD018678-dda.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 33,
       "organisms": [
@@ -6997,8 +6970,8 @@
       "file": "PXD018678-dia.sdrf.tsv",
       "filename": "PXD018678-dia.sdrf.tsv",
       "path": "datasets/PXD018678/PXD018678-dia.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018678/PXD018678-dia.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018678/PXD018678-dia.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018678/PXD018678-dia.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018678/PXD018678-dia.sdrf.tsv",
       "num_samples": 46,
       "num_columns": 33,
       "organisms": [
@@ -7023,8 +6996,8 @@
       "file": "PXD018830-DIA.sdrf.tsv",
       "filename": "PXD018830-DIA.sdrf.tsv",
       "path": "datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
       "num_samples": 25,
       "num_columns": 32,
       "organisms": [
@@ -7050,8 +7023,8 @@
       "file": "PXD018970.sdrf.tsv",
       "filename": "PXD018970.sdrf.tsv",
       "path": "datasets/PXD018970/PXD018970.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018970/PXD018970.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018970/PXD018970.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018970/PXD018970.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018970/PXD018970.sdrf.tsv",
       "num_samples": 54,
       "num_columns": 31,
       "organisms": [
@@ -7076,8 +7049,8 @@
       "file": "PXD019113.sdrf.tsv",
       "filename": "PXD019113.sdrf.tsv",
       "path": "datasets/PXD019113/PXD019113.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019113/PXD019113.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019113/PXD019113.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019113/PXD019113.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019113/PXD019113.sdrf.tsv",
       "num_samples": 64,
       "num_columns": 34,
       "organisms": [
@@ -7101,8 +7074,8 @@
       "file": "PXD019123.sdrf.tsv",
       "filename": "PXD019123.sdrf.tsv",
       "path": "datasets/PXD019123/PXD019123.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019123/PXD019123.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019123/PXD019123.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019123/PXD019123.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019123/PXD019123.sdrf.tsv",
       "num_samples": 99,
       "num_columns": 32,
       "organisms": [
@@ -7127,8 +7100,8 @@
       "file": "PXD019140.sdrf.tsv",
       "filename": "PXD019140.sdrf.tsv",
       "path": "datasets/PXD019140/PXD019140.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019140/PXD019140.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019140/PXD019140.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019140/PXD019140.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019140/PXD019140.sdrf.tsv",
       "num_samples": 21,
       "num_columns": 26,
       "organisms": [
@@ -7151,8 +7124,8 @@
       "file": "PXD019185_PXD018883.sdrf.tsv",
       "filename": "PXD019185_PXD018883.sdrf.tsv",
       "path": "datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
       "num_samples": 13,
       "num_columns": 41,
       "organisms": [
@@ -7177,8 +7150,8 @@
       "file": "PXD019288.sdrf.tsv",
       "filename": "PXD019288.sdrf.tsv",
       "path": "datasets/PXD019288/PXD019288.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019288/PXD019288.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019288/PXD019288.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019288/PXD019288.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019288/PXD019288.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 34,
       "organisms": [
@@ -7201,8 +7174,8 @@
       "file": "PXD019291.sdrf.tsv",
       "filename": "PXD019291.sdrf.tsv",
       "path": "datasets/PXD019291/PXD019291.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019291/PXD019291.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019291/PXD019291.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019291/PXD019291.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019291/PXD019291.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 28,
       "organisms": [
@@ -7225,8 +7198,8 @@
       "file": "PXD020187.sdrf.tsv",
       "filename": "PXD020187.sdrf.tsv",
       "path": "datasets/PXD020187/PXD020187.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020187/PXD020187.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020187/PXD020187.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020187/PXD020187.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020187/PXD020187.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 29,
       "organisms": [
@@ -7234,15 +7207,15 @@
       ],
       "diseases": [
         "native_5",
-        "decellularized_1",
-        "native_4",
-        "decellularized_3",
-        "native_2",
-        "native_3",
-        "native_1",
         "decellularized_4",
+        "decellularized_5",
+        "native_1",
+        "decellularized_3",
         "decellularized_2",
-        "decellularized_5"
+        "native_4",
+        "decellularized_1",
+        "native_2",
+        "native_3"
       ],
       "instruments": [
         "LTQ"
@@ -7260,8 +7233,8 @@
       "file": "PXD020192.sdrf.tsv",
       "filename": "PXD020192.sdrf.tsv",
       "path": "datasets/PXD020192/PXD020192.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020192/PXD020192.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020192/PXD020192.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020192/PXD020192.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020192/PXD020192.sdrf.tsv",
       "num_samples": 92,
       "num_columns": 30,
       "organisms": [
@@ -7286,8 +7259,8 @@
       "file": "PXD020207.sdrf.tsv",
       "filename": "PXD020207.sdrf.tsv",
       "path": "datasets/PXD020207/PXD020207.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020207/PXD020207.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020207/PXD020207.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020207/PXD020207.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020207/PXD020207.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 26,
       "organisms": [
@@ -7310,8 +7283,8 @@
       "file": "PXD020249.sdrf.tsv",
       "filename": "PXD020249.sdrf.tsv",
       "path": "datasets/PXD020249/PXD020249.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020249/PXD020249.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020249/PXD020249.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020249/PXD020249.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020249/PXD020249.sdrf.tsv",
       "num_samples": 130,
       "num_columns": 39,
       "organisms": [
@@ -7334,8 +7307,8 @@
       "file": "PXD020381.sdrf.tsv",
       "filename": "PXD020381.sdrf.tsv",
       "path": "datasets/PXD020381/PXD020381.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020381/PXD020381.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020381/PXD020381.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020381/PXD020381.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020381/PXD020381.sdrf.tsv",
       "num_samples": 370,
       "num_columns": 28,
       "organisms": [
@@ -7358,8 +7331,8 @@
       "file": "PXD020394.sdrf.tsv",
       "filename": "PXD020394.sdrf.tsv",
       "path": "datasets/PXD020394/PXD020394.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020394/PXD020394.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020394/PXD020394.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020394/PXD020394.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020394/PXD020394.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 30,
       "organisms": [
@@ -7384,8 +7357,8 @@
       "file": "PXD020785.sdrf.tsv",
       "filename": "PXD020785.sdrf.tsv",
       "path": "datasets/PXD020785/PXD020785.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020785/PXD020785.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020785/PXD020785.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020785/PXD020785.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020785/PXD020785.sdrf.tsv",
       "num_samples": 209,
       "num_columns": 31,
       "organisms": [
@@ -7409,8 +7382,8 @@
       "file": "PXD021874.sdrf.tsv",
       "filename": "PXD021874.sdrf.tsv",
       "path": "datasets/PXD021874/PXD021874.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD021874/PXD021874.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD021874/PXD021874.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD021874/PXD021874.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD021874/PXD021874.sdrf.tsv",
       "num_samples": 62,
       "num_columns": 24,
       "organisms": [
@@ -7433,8 +7406,8 @@
       "file": "PXD022070.sdrf.tsv",
       "filename": "PXD022070.sdrf.tsv",
       "path": "datasets/PXD022070/PXD022070.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD022070/PXD022070.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD022070/PXD022070.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD022070/PXD022070.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD022070/PXD022070.sdrf.tsv",
       "num_samples": 186,
       "num_columns": 28,
       "organisms": [
@@ -7457,8 +7430,8 @@
       "file": "PXD022526.sdrf.tsv",
       "filename": "PXD022526.sdrf.tsv",
       "path": "datasets/PXD022526/PXD022526.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD022526/PXD022526.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD022526/PXD022526.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD022526/PXD022526.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD022526/PXD022526.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 33,
       "organisms": [
@@ -7481,8 +7454,8 @@
       "file": "PXD023158.sdrf.tsv",
       "filename": "PXD023158.sdrf.tsv",
       "path": "datasets/PXD023158/PXD023158.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD023158/PXD023158.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD023158/PXD023158.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD023158/PXD023158.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD023158/PXD023158.sdrf.tsv",
       "num_samples": 90,
       "num_columns": 33,
       "organisms": [
@@ -7505,8 +7478,8 @@
       "file": "PXD023650.sdrf.tsv",
       "filename": "PXD023650.sdrf.tsv",
       "path": "datasets/PXD023650/PXD023650.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD023650/PXD023650.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD023650/PXD023650.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD023650/PXD023650.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD023650/PXD023650.sdrf.tsv",
       "num_samples": 123,
       "num_columns": 31,
       "organisms": [
@@ -7531,8 +7504,8 @@
       "file": "PXD023707.sdrf.tsv",
       "filename": "PXD023707.sdrf.tsv",
       "path": "datasets/PXD023707/PXD023707.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD023707/PXD023707.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD023707/PXD023707.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD023707/PXD023707.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD023707/PXD023707.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 36,
       "organisms": [
@@ -7557,8 +7530,8 @@
       "file": "PXD024138.sdrf.tsv",
       "filename": "PXD024138.sdrf.tsv",
       "path": "datasets/PXD024138/PXD024138.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD024138/PXD024138.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD024138/PXD024138.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD024138/PXD024138.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD024138/PXD024138.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 32,
       "organisms": [
@@ -7581,8 +7554,8 @@
       "file": "PXD025088.sdrf.tsv",
       "filename": "PXD025088.sdrf.tsv",
       "path": "datasets/PXD025088/PXD025088.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD025088/PXD025088.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD025088/PXD025088.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD025088/PXD025088.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD025088/PXD025088.sdrf.tsv",
       "num_samples": 16,
       "num_columns": 34,
       "organisms": [
@@ -7605,8 +7578,8 @@
       "file": "PXD025706.sdrf.tsv",
       "filename": "PXD025706.sdrf.tsv",
       "path": "datasets/PXD025706/PXD025706.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD025706/PXD025706.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD025706/PXD025706.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD025706/PXD025706.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD025706/PXD025706.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 34,
       "organisms": [
@@ -7614,8 +7587,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Q Exactive HF",
-        "Q Exactive"
+        "Q Exactive",
+        "Q Exactive HF"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -7630,8 +7603,8 @@
       "file": "PXD026474.sdrf.tsv",
       "filename": "PXD026474.sdrf.tsv",
       "path": "datasets/PXD026474/PXD026474.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD026474/PXD026474.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD026474/PXD026474.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD026474/PXD026474.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD026474/PXD026474.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 32,
       "organisms": [
@@ -7654,8 +7627,8 @@
       "file": "PXD029347.sdrf.tsv",
       "filename": "PXD029347.sdrf.tsv",
       "path": "datasets/PXD029347/PXD029347.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD029347/PXD029347.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD029347/PXD029347.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD029347/PXD029347.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD029347/PXD029347.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 28,
       "organisms": [
@@ -7678,8 +7651,8 @@
       "file": "PXD029931.sdrf.tsv",
       "filename": "PXD029931.sdrf.tsv",
       "path": "datasets/PXD029931/PXD029931.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD029931/PXD029931.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD029931/PXD029931.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD029931/PXD029931.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD029931/PXD029931.sdrf.tsv",
       "num_samples": 21,
       "num_columns": 34,
       "organisms": [
@@ -7702,8 +7675,8 @@
       "file": "PXD030345.sdrf.tsv",
       "filename": "PXD030345.sdrf.tsv",
       "path": "datasets/PXD030345/PXD030345.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD030345/PXD030345.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD030345/PXD030345.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD030345/PXD030345.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD030345/PXD030345.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 34,
       "organisms": [
@@ -7726,8 +7699,8 @@
       "file": "PXD030346.sdrf.tsv",
       "filename": "PXD030346.sdrf.tsv",
       "path": "datasets/PXD030346/PXD030346.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD030346/PXD030346.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD030346/PXD030346.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD030346/PXD030346.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD030346/PXD030346.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 34,
       "organisms": [
@@ -7750,8 +7723,8 @@
       "file": "PXD030650.sdrf.tsv",
       "filename": "PXD030650.sdrf.tsv",
       "path": "datasets/PXD030650/PXD030650.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD030650/PXD030650.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD030650/PXD030650.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD030650/PXD030650.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD030650/PXD030650.sdrf.tsv",
       "num_samples": 60,
       "num_columns": 31,
       "organisms": [
@@ -7774,8 +7747,8 @@
       "file": "PXD030690.sdrf.tsv",
       "filename": "PXD030690.sdrf.tsv",
       "path": "datasets/PXD030690/PXD030690.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD030690/PXD030690.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD030690/PXD030690.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD030690/PXD030690.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD030690/PXD030690.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 30,
       "organisms": [
@@ -7798,8 +7771,8 @@
       "file": "PXD031694.sdrf.tsv",
       "filename": "PXD031694.sdrf.tsv",
       "path": "datasets/PXD031694/PXD031694.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD031694/PXD031694.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD031694/PXD031694.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD031694/PXD031694.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD031694/PXD031694.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 27,
       "organisms": [
@@ -7822,8 +7795,8 @@
       "file": "PXD032954.sdrf.tsv",
       "filename": "PXD032954.sdrf.tsv",
       "path": "datasets/PXD032954/PXD032954.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD032954/PXD032954.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD032954/PXD032954.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD032954/PXD032954.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD032954/PXD032954.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 34,
       "organisms": [
@@ -7846,8 +7819,8 @@
       "file": "PXD035590.sdrf.tsv",
       "filename": "PXD035590.sdrf.tsv",
       "path": "datasets/PXD035590/PXD035590.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD035590/PXD035590.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD035590/PXD035590.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD035590/PXD035590.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD035590/PXD035590.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 27,
       "organisms": [
@@ -7870,8 +7843,8 @@
       "file": "PXD036749.sdrf.tsv",
       "filename": "PXD036749.sdrf.tsv",
       "path": "datasets/PXD036749/PXD036749.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD036749/PXD036749.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD036749/PXD036749.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD036749/PXD036749.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD036749/PXD036749.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 30,
       "organisms": [
@@ -7894,8 +7867,8 @@
       "file": "PXD037221.sdrf.tsv",
       "filename": "PXD037221.sdrf.tsv",
       "path": "datasets/PXD037221/PXD037221.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD037221/PXD037221.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD037221/PXD037221.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD037221/PXD037221.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD037221/PXD037221.sdrf.tsv",
       "num_samples": 90,
       "num_columns": 27,
       "organisms": [
@@ -7918,8 +7891,8 @@
       "file": "PXD040621.sdrf.tsv",
       "filename": "PXD040621.sdrf.tsv",
       "path": "datasets/PXD040621/PXD040621.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD040621/PXD040621.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD040621/PXD040621.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD040621/PXD040621.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD040621/PXD040621.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 29,
       "organisms": [
@@ -7942,8 +7915,8 @@
       "file": "PXD041301.sdrf.tsv",
       "filename": "PXD041301.sdrf.tsv",
       "path": "datasets/PXD041301/PXD041301.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD041301/PXD041301.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD041301/PXD041301.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD041301/PXD041301.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD041301/PXD041301.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 32,
       "organisms": [
@@ -7966,8 +7939,8 @@
       "file": "PXD042173.sdrf.tsv",
       "filename": "PXD042173.sdrf.tsv",
       "path": "datasets/PXD042173/PXD042173.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD042173/PXD042173.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD042173/PXD042173.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD042173/PXD042173.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD042173/PXD042173.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 27,
       "organisms": [
@@ -7990,8 +7963,8 @@
       "file": "PXD043473.sdrf.tsv",
       "filename": "PXD043473.sdrf.tsv",
       "path": "datasets/PXD043473/PXD043473.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD043473/PXD043473.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD043473/PXD043473.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD043473/PXD043473.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD043473/PXD043473.sdrf.tsv",
       "num_samples": 129,
       "num_columns": 27,
       "organisms": [
@@ -7999,8 +7972,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Orbitrap Eclipse",
-        "Q Exactive HF"
+        "Q Exactive HF",
+        "Orbitrap Eclipse"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -8015,8 +7988,8 @@
       "file": "PXD045084.sdrf.tsv",
       "filename": "PXD045084.sdrf.tsv",
       "path": "datasets/PXD045084/PXD045084.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD045084/PXD045084.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD045084/PXD045084.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD045084/PXD045084.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD045084/PXD045084.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 27,
       "organisms": [
@@ -8039,8 +8012,8 @@
       "file": "PXD050358.sdrf.tsv",
       "filename": "PXD050358.sdrf.tsv",
       "path": "datasets/PXD050358/PXD050358.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD050358/PXD050358.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD050358/PXD050358.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD050358/PXD050358.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD050358/PXD050358.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 29,
       "organisms": [
@@ -8063,8 +8036,8 @@
       "file": "PXD058808.sdrf.tsv",
       "filename": "PXD058808.sdrf.tsv",
       "path": "datasets/PXD058808/PXD058808.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD058808/PXD058808.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD058808/PXD058808.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD058808/PXD058808.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD058808/PXD058808.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 30,
       "organisms": [
@@ -8072,8 +8045,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Q Exactive HF-X",
-        "timsTOF Pro 2"
+        "timsTOF Pro 2",
+        "Q Exactive HF-X"
       ],
       "acquisition_methods": [
         "data-dependent acquisition"

--- a/site/sdrf-explorer.html
+++ b/site/sdrf-explorer.html
@@ -308,11 +308,11 @@
     <script id="sdrf-data" type="application/json">
 {
   "statistics": {
-    "total_datasets": 298,
-    "total_samples": 80289,
-    "generated_at": "2026-04-17T16:17:53.486665Z",
+    "total_datasets": 297,
+    "total_samples": 76039,
+    "generated_at": "2026-04-19T06:43:46.990076Z",
     "organisms": {
-      "Homo sapiens": 51421,
+      "Homo sapiens": 47171,
       "homo sapiens": 10167,
       "Mus musculus": 4460,
       "Homo Sapiens": 3873,
@@ -344,7 +344,6 @@
       "breast": 6237,
       "lung": 5356,
       "blood plasma": 4903,
-      "Breast": 3997,
       "ovary": 3172,
       "bone marrow": 2411,
       "Muscle": 2316,
@@ -380,6 +379,7 @@
       "flower bud": 240,
       "medial frontal gyrus": 240,
       "Caco-2 cells": 240,
+      "Breast": 222,
       "root": 220,
       "Blood serum": 213,
       "Colon": 211,
@@ -394,7 +394,6 @@
     },
     "diseases": {
       "squamous cell lung cancer": 4292,
-      "Breast Invasive Carcinoma": 3775,
       "metastatic cutaneous melanoma": 3600,
       "breast cancer": 2355,
       "ovarian high grade serous adenocarcinoma": 2231,
@@ -422,7 +421,6 @@
       "colorectal adenocarcinoma": 528,
       "non-small cell lung cancer": 516,
       "colon cancer": 478,
-      "Other": 475,
       "malignant melanoma": 432,
       "Rectal Adenocarcinoma": 390,
       "Alzheimer's disease": 361,
@@ -442,13 +440,14 @@
       "Prostate adenocarcinoma": 172,
       "lung adenocarcinoma": 169,
       "hepatocellular carcinoma (HCC)": 160,
-      "colon and rectal tumors": 150
+      "colon and rectal tumors": 150,
+      "Breast cancer": 141,
+      "Triple-negative breast cancer": 141
     },
     "cell_types": {
       "epithelial cell": 5207,
       "epithelial": 4805,
       "malignant cell": 3600,
-      "Primary Tumor": 3325,
       "lymphoblast": 2298,
       "schizonts": 2032,
       "cardiac": 1803,
@@ -456,7 +455,6 @@
       "Prokaryotic cell": 1535,
       "schizont": 844,
       "melanoma cell": 764,
-      "Solid Tissue Normal": 450,
       "Cancerous cell": 276,
       "platelet": 270,
       "Epithelial": 258,
@@ -494,14 +492,16 @@
       "kidney": 40,
       "lung": 40,
       "brown adipose tissue": 39,
-      "liver": 36
+      "liver": 36,
+      "testis": 36,
+      "myoblast": 36
     },
     "instruments": {
       "Q Exactive": 18091,
-      "Orbitrap Fusion Lumos": 12286,
       "Q Exactive Plus": 10628,
       "LTQ Orbitrap Velos": 8703,
       "Q Exactive HF": 8662,
+      "Orbitrap Fusion Lumos": 8036,
       "Orbitrap Fusion": 4610,
       "orbitrap": 4359,
       "Orbitrap Elite": 3998,
@@ -532,17 +532,17 @@
     "labels": {
       "label free sample": 34037,
       "Label free": 4395,
-      "TMT126": 3702,
-      "TMT131": 3111,
+      "TMT126": 3277,
       "SILAC heavy": 2726,
-      "TMT127N": 2372,
-      "TMT128N": 2372,
-      "TMT128C": 2372,
-      "TMT129N": 2372,
-      "TMT129C": 2372,
-      "TMT130N": 2372,
-      "TMT130C": 2372,
-      "TMT127C": 2371,
+      "TMT131": 2686,
+      "TMT127N": 1947,
+      "TMT128N": 1947,
+      "TMT128C": 1947,
+      "TMT129N": 1947,
+      "TMT129C": 1947,
+      "TMT130N": 1947,
+      "TMT130C": 1947,
+      "TMT127C": 1946,
       "TMT127": 1595,
       "TMT128": 1595,
       "TMT129": 1595,
@@ -552,7 +552,7 @@
       "SILAC light": 929
     },
     "acquisition_methods": {
-      "Data-dependent acquisition": 78518,
+      "Data-dependent acquisition": 74268,
       "data-dependent acquisition": 898,
       "Data-independent acquisition": 662,
       "selected reaction monitoring": 205,
@@ -591,7 +591,7 @@
       "Ubiquitination": 78
     },
     "cleavage_agents": {
-      "Trypsin": 60748,
+      "Trypsin": 56498,
       "Lys-C": 10184,
       "Trypsin/P": 6452,
       "unspecific cleavage": 1248,
@@ -609,18 +609,18 @@
       "no cleavage": 5
     },
     "experiment_types": {
-      "DDA": 290,
+      "DDA": 289,
       "SRM/MRM": 3,
       "DIA": 5
     },
     "label_types": {
       "Label-free": 229,
-      "TMT": 36,
+      "TMT": 35,
       "SILAC": 23,
       "iTRAQ": 10
     },
     "templates": {
-      "unknown": 298
+      "unknown": 297
     }
   },
   "datasets": [
@@ -629,8 +629,8 @@
       "file": "COMBINEDPX0000001.sdrf.tsv",
       "filename": "COMBINEDPX0000001.sdrf.tsv",
       "path": "datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/COMBINEDPX0000001/COMBINEDPX0000001.sdrf.tsv",
       "num_samples": 35,
       "num_columns": 32,
       "organisms": [
@@ -658,13 +658,13 @@
       "file": "MSV000078494.sdrf.tsv",
       "filename": "MSV000078494.sdrf.tsv",
       "path": "datasets/MSV000078494/MSV000078494.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000078494/MSV000078494.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000078494/MSV000078494.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000078494/MSV000078494.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000078494/MSV000078494.sdrf.tsv",
       "num_samples": 96,
       "num_columns": 35,
       "organisms": [
-        "homo sapiens",
-        "mus musculus"
+        "mus musculus",
+        "homo sapiens"
       ],
       "diseases": [
         "melanoma"
@@ -685,8 +685,8 @@
       "file": "MSV000078535.sdrf.tsv",
       "filename": "MSV000078535.sdrf.tsv",
       "path": "datasets/MSV000078535/MSV000078535.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000078535/MSV000078535.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000078535/MSV000078535.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000078535/MSV000078535.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000078535/MSV000078535.sdrf.tsv",
       "num_samples": 44,
       "num_columns": 37,
       "organisms": [
@@ -711,8 +711,8 @@
       "file": "MSV000078555.sdrf.tsv",
       "filename": "MSV000078555.sdrf.tsv",
       "path": "datasets/MSV000078555/MSV000078555.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000078555/MSV000078555.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000078555/MSV000078555.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000078555/MSV000078555.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000078555/MSV000078555.sdrf.tsv",
       "num_samples": 176,
       "num_columns": 37,
       "organisms": [
@@ -738,20 +738,20 @@
       "file": "MSV000080451.sdrf.tsv",
       "filename": "MSV000080451.sdrf.tsv",
       "path": "datasets/MSV000080451/MSV000080451.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000080451/MSV000080451.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000080451/MSV000080451.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000080451/MSV000080451.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000080451/MSV000080451.sdrf.tsv",
       "num_samples": 71,
       "num_columns": 33,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "multiple myeloma",
-        "monoclonal gammopathy"
+        "monoclonal gammopathy",
+        "multiple myeloma"
       ],
       "instruments": [
-        "Orbitrap Elite",
-        "LTQ Orbitrap XL"
+        "LTQ Orbitrap XL",
+        "Orbitrap Elite"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -766,8 +766,8 @@
       "file": "MSV000086206.sdrf.tsv",
       "filename": "MSV000086206.sdrf.tsv",
       "path": "datasets/MSV000086206/MSV000086206.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/MSV000086206/MSV000086206.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/MSV000086206/MSV000086206.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/MSV000086206/MSV000086206.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/MSV000086206/MSV000086206.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 21,
       "organisms": [
@@ -790,8 +790,8 @@
       "file": "PMID21183079.sdrf.tsv",
       "filename": "PMID21183079.sdrf.tsv",
       "path": "datasets/PMID21183079/PMID21183079.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID21183079/PMID21183079.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID21183079/PMID21183079.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID21183079/PMID21183079.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID21183079/PMID21183079.sdrf.tsv",
       "num_samples": 347,
       "num_columns": 31,
       "organisms": [
@@ -814,17 +814,17 @@
       "file": "PMID25043054.sdrf.tsv",
       "filename": "PMID25043054.sdrf.tsv",
       "path": "datasets/PMID25043054/PMID25043054.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID25043054/PMID25043054.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID25043054/PMID25043054.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID25043054/PMID25043054.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID25043054/PMID25043054.sdrf.tsv",
       "num_samples": 1425,
       "num_columns": 41,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
+        "Colon Adenocarcinoma",
         "Colon Mucinous Adenocarcinoma",
         "Rectal Adenocarcinoma",
-        "Colon Adenocarcinoma",
         "Rectal Mucinous Adenocarcinoma"
       ],
       "instruments": [
@@ -843,8 +843,8 @@
       "file": "PMID28625833.sdrf.tsv",
       "filename": "PMID28625833.sdrf.tsv",
       "path": "datasets/PMID28625833/PMID28625833.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID28625833/PMID28625833.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID28625833/PMID28625833.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID28625833/PMID28625833.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID28625833/PMID28625833.sdrf.tsv",
       "num_samples": 660,
       "num_columns": 32,
       "organisms": [
@@ -869,8 +869,8 @@
       "file": "PMID31975593.sdrf.tsv",
       "filename": "PMID31975593.sdrf.tsv",
       "path": "datasets/PMID31975593/PMID31975593.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID31975593/PMID31975593.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID31975593/PMID31975593.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID31975593/PMID31975593.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID31975593/PMID31975593.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 33,
       "organisms": [
@@ -895,8 +895,8 @@
       "file": "PMID33086064.sdrf.tsv",
       "filename": "PMID33086064.sdrf.tsv",
       "path": "datasets/PMID33086064/PMID33086064.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID33086064/PMID33086064.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID33086064/PMID33086064.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PMID33086064/PMID33086064.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PMID33086064/PMID33086064.sdrf.tsv",
       "num_samples": 3120,
       "num_columns": 39,
       "organisms": [
@@ -918,39 +918,12 @@
       "version": "unknown"
     },
     {
-      "id": "PMID33212010",
-      "file": "PMID33212010.sdrf.tsv",
-      "filename": "PMID33212010.sdrf.tsv",
-      "path": "datasets/PMID33212010/PMID33212010.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PMID33212010/PMID33212010.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PMID33212010/PMID33212010.sdrf.tsv",
-      "num_samples": 4250,
-      "num_columns": 37,
-      "organisms": [
-        "Homo sapiens"
-      ],
-      "diseases": [
-        "Breast Invasive Carcinoma",
-        "Other"
-      ],
-      "instruments": [
-        "Orbitrap Fusion Lumos"
-      ],
-      "acquisition_methods": [
-        "Data-dependent acquisition"
-      ],
-      "experiment_type": "DDA",
-      "label_type": "TMT",
-      "template": "unknown",
-      "version": "unknown"
-    },
-    {
       "id": "PXD000070",
       "file": "PXD000070.sdrf.tsv",
       "filename": "PXD000070.sdrf.tsv",
       "path": "datasets/PXD000070/PXD000070.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000070/PXD000070.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000070/PXD000070.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000070/PXD000070.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000070/PXD000070.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 31,
       "organisms": [
@@ -973,8 +946,8 @@
       "file": "PXD000228.sdrf.tsv",
       "filename": "PXD000228.sdrf.tsv",
       "path": "datasets/PXD000228/PXD000228.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000228/PXD000228.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000228/PXD000228.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000228/PXD000228.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000228/PXD000228.sdrf.tsv",
       "num_samples": 270,
       "num_columns": 35,
       "organisms": [
@@ -997,8 +970,8 @@
       "file": "PXD000288.sdrf.tsv",
       "filename": "PXD000288.sdrf.tsv",
       "path": "datasets/PXD000288/PXD000288.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000288/PXD000288.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000288/PXD000288.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000288/PXD000288.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000288/PXD000288.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 36,
       "organisms": [
@@ -1021,8 +994,8 @@
       "file": "PXD000312.sdrf.tsv",
       "filename": "PXD000312.sdrf.tsv",
       "path": "datasets/PXD000312/PXD000312.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000312/PXD000312.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000312/PXD000312.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000312/PXD000312.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000312/PXD000312.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 29,
       "organisms": [
@@ -1047,8 +1020,8 @@
       "file": "PXD000396.sdrf.tsv",
       "filename": "PXD000396.sdrf.tsv",
       "path": "datasets/PXD000396/PXD000396.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000396/PXD000396.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000396/PXD000396.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000396/PXD000396.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000396/PXD000396.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 35,
       "organisms": [
@@ -1073,8 +1046,8 @@
       "file": "PXD000498.sdrf.tsv",
       "filename": "PXD000498.sdrf.tsv",
       "path": "datasets/PXD000498/PXD000498.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000498/PXD000498.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000498/PXD000498.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000498/PXD000498.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000498/PXD000498.sdrf.tsv",
       "num_samples": 84,
       "num_columns": 37,
       "organisms": [
@@ -1097,8 +1070,8 @@
       "file": "PXD000527.sdrf.tsv",
       "filename": "PXD000527.sdrf.tsv",
       "path": "datasets/PXD000527/PXD000527.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000527/PXD000527.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000527/PXD000527.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000527/PXD000527.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000527/PXD000527.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 26,
       "organisms": [
@@ -1121,8 +1094,8 @@
       "file": "PXD000534.sdrf.tsv",
       "filename": "PXD000534.sdrf.tsv",
       "path": "datasets/PXD000534/PXD000534.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000534/PXD000534.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000534/PXD000534.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000534/PXD000534.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000534/PXD000534.sdrf.tsv",
       "num_samples": 16,
       "num_columns": 30,
       "organisms": [
@@ -1147,17 +1120,17 @@
       "file": "PXD000547.sdrf.tsv",
       "filename": "PXD000547.sdrf.tsv",
       "path": "datasets/PXD000547/PXD000547.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000547/PXD000547.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000547/PXD000547.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000547/PXD000547.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000547/PXD000547.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 34,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "lung embolism",
         "cardiopulmonary insufficiency",
-        "heart infarction"
+        "heart infarction",
+        "lung embolism"
       ],
       "instruments": [
         "LTQ Orbitrap XL"
@@ -1175,17 +1148,17 @@
       "file": "PXD000548.sdrf.tsv",
       "filename": "PXD000548.sdrf.tsv",
       "path": "datasets/PXD000548/PXD000548.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000548/PXD000548.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000548/PXD000548.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000548/PXD000548.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000548/PXD000548.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 31,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "lung embolism",
         "cardiopulmonary insufficiency",
-        "heart infarction"
+        "heart infarction",
+        "lung embolism"
       ],
       "instruments": [
         "LTQ Orbitrap XL"
@@ -1203,8 +1176,8 @@
       "file": "PXD000561.sdrf.tsv",
       "filename": "PXD000561.sdrf.tsv",
       "path": "datasets/PXD000561/PXD000561.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000561/PXD000561.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000561/PXD000561.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000561/PXD000561.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000561/PXD000561.sdrf.tsv",
       "num_samples": 2212,
       "num_columns": 36,
       "organisms": [
@@ -1228,8 +1201,8 @@
       "file": "PXD000612.sdrf.tsv",
       "filename": "PXD000612.sdrf.tsv",
       "path": "datasets/PXD000612/PXD000612.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000612/PXD000612.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000612/PXD000612.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000612/PXD000612.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000612/PXD000612.sdrf.tsv",
       "num_samples": 273,
       "num_columns": 37,
       "organisms": [
@@ -1254,8 +1227,8 @@
       "file": "PXD000651.sdrf.tsv",
       "filename": "PXD000651.sdrf.tsv",
       "path": "datasets/PXD000651/PXD000651.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000651/PXD000651.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000651/PXD000651.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000651/PXD000651.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000651/PXD000651.sdrf.tsv",
       "num_samples": 37,
       "num_columns": 32,
       "organisms": [
@@ -1280,8 +1253,8 @@
       "file": "PXD000652.sdrf.tsv",
       "filename": "PXD000652.sdrf.tsv",
       "path": "datasets/PXD000652/PXD000652.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000652/PXD000652.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000652/PXD000652.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000652/PXD000652.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000652/PXD000652.sdrf.tsv",
       "num_samples": 46,
       "num_columns": 32,
       "organisms": [
@@ -1306,8 +1279,8 @@
       "file": "PXD000759.sdrf.tsv",
       "filename": "PXD000759.sdrf.tsv",
       "path": "datasets/PXD000759/PXD000759.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000759/PXD000759.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000759/PXD000759.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000759/PXD000759.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000759/PXD000759.sdrf.tsv",
       "num_samples": 336,
       "num_columns": 33,
       "organisms": [
@@ -1332,8 +1305,8 @@
       "file": "PXD000790.sdrf.tsv",
       "filename": "PXD000790.sdrf.tsv",
       "path": "datasets/PXD000790/PXD000790.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000790/PXD000790.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000790/PXD000790.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000790/PXD000790.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000790/PXD000790.sdrf.tsv",
       "num_samples": 1,
       "num_columns": 30,
       "organisms": [
@@ -1356,8 +1329,8 @@
       "file": "PXD000792.sdrf.tsv",
       "filename": "PXD000792.sdrf.tsv",
       "path": "datasets/PXD000792/PXD000792.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000792/PXD000792.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000792/PXD000792.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000792/PXD000792.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000792/PXD000792.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 23,
       "organisms": [
@@ -1380,8 +1353,8 @@
       "file": "PXD000793.sdrf.tsv",
       "filename": "PXD000793.sdrf.tsv",
       "path": "datasets/PXD000793/PXD000793.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000793/PXD000793.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000793/PXD000793.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000793/PXD000793.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000793/PXD000793.sdrf.tsv",
       "num_samples": 116,
       "num_columns": 28,
       "organisms": [
@@ -1404,8 +1377,8 @@
       "file": "PXD000815.sdrf.tsv",
       "filename": "PXD000815.sdrf.tsv",
       "path": "datasets/PXD000815/PXD000815.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000815/PXD000815.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000815/PXD000815.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000815/PXD000815.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000815/PXD000815.sdrf.tsv",
       "num_samples": 454,
       "num_columns": 35,
       "organisms": [
@@ -1430,8 +1403,8 @@
       "file": "PXD000857.sdrf.tsv",
       "filename": "PXD000857.sdrf.tsv",
       "path": "datasets/PXD000857/PXD000857.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000857/PXD000857.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000857/PXD000857.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000857/PXD000857.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000857/PXD000857.sdrf.tsv",
       "num_samples": 1,
       "num_columns": 26,
       "organisms": [
@@ -1454,8 +1427,8 @@
       "file": "PXD000895.sdrf.tsv",
       "filename": "PXD000895.sdrf.tsv",
       "path": "datasets/PXD000895/PXD000895.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000895/PXD000895.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000895/PXD000895.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000895/PXD000895.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000895/PXD000895.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 29,
       "organisms": [
@@ -1480,8 +1453,8 @@
       "file": "PXD000923.sdrf.tsv",
       "filename": "PXD000923.sdrf.tsv",
       "path": "datasets/PXD000923/PXD000923.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000923/PXD000923.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000923/PXD000923.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000923/PXD000923.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000923/PXD000923.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 27,
       "organisms": [
@@ -1504,8 +1477,8 @@
       "file": "PXD000999.sdrf.tsv",
       "filename": "PXD000999.sdrf.tsv",
       "path": "datasets/PXD000999/PXD000999.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD000999/PXD000999.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD000999/PXD000999.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD000999/PXD000999.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD000999/PXD000999.sdrf.tsv",
       "num_samples": 7,
       "num_columns": 34,
       "organisms": [
@@ -1530,8 +1503,8 @@
       "file": "PXD001061.sdrf.tsv",
       "filename": "PXD001061.sdrf.tsv",
       "path": "datasets/PXD001061/PXD001061.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001061/PXD001061.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001061/PXD001061.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001061/PXD001061.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001061/PXD001061.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 38,
       "organisms": [
@@ -1556,8 +1529,8 @@
       "file": "PXD001168.sdrf.tsv",
       "filename": "PXD001168.sdrf.tsv",
       "path": "datasets/PXD001168/PXD001168.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001168/PXD001168.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001168/PXD001168.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001168/PXD001168.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001168/PXD001168.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 26,
       "organisms": [
@@ -1580,8 +1553,8 @@
       "file": "PXD001224.sdrf.tsv",
       "filename": "PXD001224.sdrf.tsv",
       "path": "datasets/PXD001224/PXD001224.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001224/PXD001224.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001224/PXD001224.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001224/PXD001224.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001224/PXD001224.sdrf.tsv",
       "num_samples": 108,
       "num_columns": 35,
       "organisms": [
@@ -1604,8 +1577,8 @@
       "file": "PXD001325.sdrf.tsv",
       "filename": "PXD001325.sdrf.tsv",
       "path": "datasets/PXD001325/PXD001325.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001325/PXD001325.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001325/PXD001325.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001325/PXD001325.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001325/PXD001325.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 31,
       "organisms": [
@@ -1630,8 +1603,8 @@
       "file": "PXD001281.sdrf.tsv",
       "filename": "PXD001281.sdrf.tsv",
       "path": "datasets/PXD001381/PXD001281.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001381/PXD001281.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001381/PXD001281.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001381/PXD001281.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001381/PXD001281.sdrf.tsv",
       "num_samples": 84,
       "num_columns": 18,
       "organisms": [
@@ -1656,8 +1629,8 @@
       "file": "PXD001404.sdrf.tsv",
       "filename": "PXD001404.sdrf.tsv",
       "path": "datasets/PXD001404/PXD001404.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001404/PXD001404.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001404/PXD001404.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001404/PXD001404.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001404/PXD001404.sdrf.tsv",
       "num_samples": 154,
       "num_columns": 31,
       "organisms": [
@@ -1680,8 +1653,8 @@
       "file": "PXD001468.sdrf.tsv",
       "filename": "PXD001468.sdrf.tsv",
       "path": "datasets/PXD001468/PXD001468.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001468/PXD001468.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001468/PXD001468.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001468/PXD001468.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001468/PXD001468.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 39,
       "organisms": [
@@ -1704,8 +1677,8 @@
       "file": "PXD001474.sdrf.tsv",
       "filename": "PXD001474.sdrf.tsv",
       "path": "datasets/PXD001474/PXD001474.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001474/PXD001474.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001474/PXD001474.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001474/PXD001474.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001474/PXD001474.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 30,
       "organisms": [
@@ -1730,8 +1703,8 @@
       "file": "PXD001487.sdrf.tsv",
       "filename": "PXD001487.sdrf.tsv",
       "path": "datasets/PXD001487/PXD001487.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001487/PXD001487.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001487/PXD001487.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001487/PXD001487.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001487/PXD001487.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 35,
       "organisms": [
@@ -1756,8 +1729,8 @@
       "file": "PXD001558.sdrf.tsv",
       "filename": "PXD001558.sdrf.tsv",
       "path": "datasets/PXD001558/PXD001558.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001558/PXD001558.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001558/PXD001558.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001558/PXD001558.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001558/PXD001558.sdrf.tsv",
       "num_samples": 123,
       "num_columns": 21,
       "organisms": [
@@ -1782,8 +1755,8 @@
       "file": "PXD001684.sdrf.tsv",
       "filename": "PXD001684.sdrf.tsv",
       "path": "datasets/PXD001684/PXD001684.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001684/PXD001684.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001684/PXD001684.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001684/PXD001684.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001684/PXD001684.sdrf.tsv",
       "num_samples": 71,
       "num_columns": 31,
       "organisms": [
@@ -1806,8 +1779,8 @@
       "file": "PXD001725.sdrf.tsv",
       "filename": "PXD001725.sdrf.tsv",
       "path": "datasets/PXD001725/PXD001725.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001725/PXD001725.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001725/PXD001725.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001725/PXD001725.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001725/PXD001725.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 31,
       "organisms": [
@@ -1832,8 +1805,8 @@
       "file": "PXD001736.sdrf.tsv",
       "filename": "PXD001736.sdrf.tsv",
       "path": "datasets/PXD001736/PXD001736.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001736/PXD001736.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001736/PXD001736.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001736/PXD001736.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001736/PXD001736.sdrf.tsv",
       "num_samples": 84,
       "num_columns": 37,
       "organisms": [
@@ -1858,8 +1831,8 @@
       "file": "PXD001774.sdrf.tsv",
       "filename": "PXD001774.sdrf.tsv",
       "path": "datasets/PXD001774/PXD001774.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001774/PXD001774.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001774/PXD001774.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001774/PXD001774.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001774/PXD001774.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 27,
       "organisms": [
@@ -1882,8 +1855,8 @@
       "file": "PXD001819.sdrf.tsv",
       "filename": "PXD001819.sdrf.tsv",
       "path": "datasets/PXD001819/PXD001819.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD001819/PXD001819.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD001819/PXD001819.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD001819/PXD001819.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD001819/PXD001819.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 27,
       "organisms": [
@@ -1906,8 +1879,8 @@
       "file": "PXD002029.sdrf.tsv",
       "filename": "PXD002029.sdrf.tsv",
       "path": "datasets/PXD002029/PXD002029.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002029/PXD002029.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002029/PXD002029.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002029/PXD002029.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002029/PXD002029.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 34,
       "organisms": [
@@ -1932,8 +1905,8 @@
       "file": "PXD002049.sdrf.tsv",
       "filename": "PXD002049.sdrf.tsv",
       "path": "datasets/PXD002049/PXD002049.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002049/PXD002049.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002049/PXD002049.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002049/PXD002049.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002049/PXD002049.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 33,
       "organisms": [
@@ -1958,8 +1931,8 @@
       "file": "PXD002080.sdrf.tsv",
       "filename": "PXD002080.sdrf.tsv",
       "path": "datasets/PXD002080/PXD002080.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002080/PXD002080.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002080/PXD002080.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002080/PXD002080.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002080/PXD002080.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 30,
       "organisms": [
@@ -1984,8 +1957,8 @@
       "file": "PXD002081.sdrf.tsv",
       "filename": "PXD002081.sdrf.tsv",
       "path": "datasets/PXD002081/PXD002081.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002081/PXD002081.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002081/PXD002081.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002081/PXD002081.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002081/PXD002081.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 30,
       "organisms": [
@@ -2010,8 +1983,8 @@
       "file": "PXD002082.sdrf.tsv",
       "filename": "PXD002082.sdrf.tsv",
       "path": "datasets/PXD002082/PXD002082.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002082/PXD002082.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002082/PXD002082.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002082/PXD002082.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002082/PXD002082.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 31,
       "organisms": [
@@ -2036,8 +2009,8 @@
       "file": "PXD002084.sdrf.tsv",
       "filename": "PXD002084.sdrf.tsv",
       "path": "datasets/PXD002084/PXD002084.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002084/PXD002084.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002084/PXD002084.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002084/PXD002084.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002084/PXD002084.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 30,
       "organisms": [
@@ -2062,16 +2035,16 @@
       "file": "PXD002086.sdrf.tsv",
       "filename": "PXD002086.sdrf.tsv",
       "path": "datasets/PXD002086/PXD002086.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002086/PXD002086.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002086/PXD002086.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002086/PXD002086.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002086/PXD002086.sdrf.tsv",
       "num_samples": 153,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "Rectum adenocarcinoma",
-        "Colon adenocarcinoma"
+        "Colon adenocarcinoma",
+        "Rectum adenocarcinoma"
       ],
       "instruments": [
         "LTQ Orbitrap Velos"
@@ -2089,8 +2062,8 @@
       "file": "PXD002087.sdrf.tsv",
       "filename": "PXD002087.sdrf.tsv",
       "path": "datasets/PXD002087/PXD002087.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002087/PXD002087.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002087/PXD002087.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002087/PXD002087.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002087/PXD002087.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 30,
       "organisms": [
@@ -2115,8 +2088,8 @@
       "file": "PXD002088.sdrf.tsv",
       "filename": "PXD002088.sdrf.tsv",
       "path": "datasets/PXD002088/PXD002088.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002088/PXD002088.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002088/PXD002088.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002088/PXD002088.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002088/PXD002088.sdrf.tsv",
       "num_samples": 150,
       "num_columns": 28,
       "organisms": [
@@ -2142,8 +2115,8 @@
       "file": "PXD002171.sdrf.tsv",
       "filename": "PXD002171.sdrf.tsv",
       "path": "datasets/PXD002171/PXD002171.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002171/PXD002171.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002171/PXD002171.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002171/PXD002171.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002171/PXD002171.sdrf.tsv",
       "num_samples": 38,
       "num_columns": 35,
       "organisms": [
@@ -2168,19 +2141,19 @@
       "file": "PXD002192.sdrf.tsv",
       "filename": "PXD002192.sdrf.tsv",
       "path": "datasets/PXD002192/PXD002192.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002192/PXD002192.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002192/PXD002192.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002192/PXD002192.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002192/PXD002192.sdrf.tsv",
       "num_samples": 276,
       "num_columns": 35,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "Breast Adenocarcinoma",
         "Breast Cancer",
-        "Mlignant Melanoma",
         "Glioblastoma",
-        "Pancreatic Carcinoma"
+        "Pancreatic Carcinoma",
+        "Breast Adenocarcinoma",
+        "Mlignant Melanoma"
       ],
       "instruments": [
         "LTQ Orbitrap Velos"
@@ -2198,8 +2171,8 @@
       "file": "PXD002222.sdrf.tsv",
       "filename": "PXD002222.sdrf.tsv",
       "path": "datasets/PXD002222/PXD002222.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002222/PXD002222.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002222/PXD002222.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002222/PXD002222.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002222/PXD002222.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 28,
       "organisms": [
@@ -2224,8 +2197,8 @@
       "file": "PXD002255.sdrf.tsv",
       "filename": "PXD002255.sdrf.tsv",
       "path": "datasets/PXD002255/PXD002255.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002255/PXD002255.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002255/PXD002255.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002255/PXD002255.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002255/PXD002255.sdrf.tsv",
       "num_samples": 428,
       "num_columns": 35,
       "organisms": [
@@ -2250,8 +2223,8 @@
       "file": "PXD002266.sdrf.tsv",
       "filename": "PXD002266.sdrf.tsv",
       "path": "datasets/PXD002266/PXD002266.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002266/PXD002266.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002266/PXD002266.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002266/PXD002266.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002266/PXD002266.sdrf.tsv",
       "num_samples": 216,
       "num_columns": 28,
       "organisms": [
@@ -2274,8 +2247,8 @@
       "file": "PXD002370.sdrf.tsv",
       "filename": "PXD002370.sdrf.tsv",
       "path": "datasets/PXD002370/PXD002370.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002370/PXD002370.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002370/PXD002370.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002370/PXD002370.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002370/PXD002370.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 32,
       "organisms": [
@@ -2298,24 +2271,24 @@
       "file": "PXD002395.sdrf.tsv",
       "filename": "PXD002395.sdrf.tsv",
       "path": "datasets/PXD002395/PXD002395.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002395/PXD002395.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002395/PXD002395.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002395/PXD002395.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002395/PXD002395.sdrf.tsv",
       "num_samples": 198,
       "num_columns": 36,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
+        "Colon carcinoma",
+        "Human papillomavirus-related endocervical adenocarcinoma",
+        "Glioblastoma",
         "Prostate carcinoma",
         "Osteosarcoma",
-        "Hepatoblastoma",
         "Childhood T acute lymphoblastic leukemia",
-        "Human papillomavirus-related endocervical adenocarcinoma",
-        "Chronic myelogenous leukemia, BCR-ABL1 positive",
         "Lung adenocarcinoma",
-        "Glioblastoma",
+        "Chronic myelogenous leukemia, BCR-ABL1 positive",
         "Invasive ductal carcinoma, not otherwise specified",
-        "Colon carcinoma"
+        "Hepatoblastoma"
       ],
       "instruments": [
         "LTQ Orbitrap Velos"
@@ -2333,8 +2306,8 @@
       "file": "PXD002756.sdrf.tsv",
       "filename": "PXD002756.sdrf.tsv",
       "path": "datasets/PXD002756/PXD002756.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002756/PXD002756.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002756/PXD002756.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002756/PXD002756.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002756/PXD002756.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 29,
       "organisms": [
@@ -2357,8 +2330,8 @@
       "file": "PXD002815.sdrf.tsv",
       "filename": "PXD002815.sdrf.tsv",
       "path": "datasets/PXD002815/PXD002815.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002815/PXD002815.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002815/PXD002815.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002815/PXD002815.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002815/PXD002815.sdrf.tsv",
       "num_samples": 4311,
       "num_columns": 21,
       "organisms": [
@@ -2382,8 +2355,8 @@
       "file": "PXD002870.sdrf.tsv",
       "filename": "PXD002870.sdrf.tsv",
       "path": "datasets/PXD002870/PXD002870.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD002870/PXD002870.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD002870/PXD002870.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD002870/PXD002870.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD002870/PXD002870.sdrf.tsv",
       "num_samples": 1477,
       "num_columns": 33,
       "organisms": [
@@ -2406,8 +2379,8 @@
       "file": "PXD003028.sdrf.tsv",
       "filename": "PXD003028.sdrf.tsv",
       "path": "datasets/PXD003028/PXD003028.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003028/PXD003028.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003028/PXD003028.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003028/PXD003028.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003028/PXD003028.sdrf.tsv",
       "num_samples": 89,
       "num_columns": 35,
       "organisms": [
@@ -2430,8 +2403,8 @@
       "file": "PXD003133.sdrf.tsv",
       "filename": "PXD003133.sdrf.tsv",
       "path": "datasets/PXD003133/PXD003133.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003133/PXD003133.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003133/PXD003133.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003133/PXD003133.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003133/PXD003133.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 28,
       "organisms": [
@@ -2454,8 +2427,8 @@
       "file": "PXD003209.sdrf.tsv",
       "filename": "PXD003209.sdrf.tsv",
       "path": "datasets/PXD003209/PXD003209.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003209/PXD003209.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003209/PXD003209.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003209/PXD003209.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003209/PXD003209.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 29,
       "organisms": [
@@ -2480,16 +2453,16 @@
       "file": "PXD003430.sdrf.tsv",
       "filename": "PXD003430.sdrf.tsv",
       "path": "datasets/PXD003430/PXD003430.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003430/PXD003430.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003430/PXD003430.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003430/PXD003430.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003430/PXD003430.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2507,16 +2480,16 @@
       "file": "PXD003452.sdrf.tsv",
       "filename": "PXD003452.sdrf.tsv",
       "path": "datasets/PXD003452/PXD003452.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003452/PXD003452.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003452/PXD003452.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003452/PXD003452.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003452/PXD003452.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2534,35 +2507,35 @@
       "file": "PXD003469.sdrf.tsv",
       "filename": "PXD003469.sdrf.tsv",
       "path": "datasets/PXD003469/PXD003469.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003469/PXD003469.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003469/PXD003469.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003469/PXD003469.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003469/PXD003469.sdrf.tsv",
       "num_samples": 382,
       "num_columns": 34,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "Burkitt's lymphoma (American)",
-        "diffuse histiocytic lymphoma",
-        "Primary mediastinal large B-cell lymphoma",
-        "Aggressive NK-cell leukemia",
-        "Anaplastic large cell lymphoma",
-        "Anaplastic large cell lymphoma,",
+        "malignant non-Hodgkin's lymphoma",
+        "Multiple Myeloma",
+        "Burkitt's lymphoma",
         "cutaneous T cell lymphoma",
         "Burkitt lymphoma",
-        "malignant non-Hodgkin's lymphoma",
-        "Transformed follicular lymphoma",
-        "Burkitt's lymphoma",
-        "Nodular lymphocyte predominant Hodgkin lymphoma",
-        "plasmacytoma",
-        "follicular lymphoma",
-        "acute T cell leukemia",
-        "Diffuse large B-cell lymphoma",
-        "Sezary Syndrome",
-        "lymphoma",
-        "Classical Hodgkin lymphoma",
+        "Aggressive NK-cell leukemia",
         "Mantle cell lymphoma",
-        "Multiple Myeloma"
+        "Anaplastic large cell lymphoma,",
+        "acute T cell leukemia",
+        "Sezary Syndrome",
+        "Transformed follicular lymphoma",
+        "plasmacytoma",
+        "Anaplastic large cell lymphoma",
+        "Classical Hodgkin lymphoma",
+        "follicular lymphoma",
+        "diffuse histiocytic lymphoma",
+        "Nodular lymphocyte predominant Hodgkin lymphoma",
+        "Diffuse large B-cell lymphoma",
+        "lymphoma",
+        "Primary mediastinal large B-cell lymphoma",
+        "Burkitt's lymphoma (American)"
       ],
       "instruments": [
         "LTQ Orbitrap XL"
@@ -2580,16 +2553,16 @@
       "file": "PXD003515.sdrf.tsv",
       "filename": "PXD003515.sdrf.tsv",
       "path": "datasets/PXD003515/PXD003515.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003515/PXD003515.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003515/PXD003515.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003515/PXD003515.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003515/PXD003515.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2607,20 +2580,20 @@
       "file": "PXD003531.sdrf.tsv",
       "filename": "PXD003531.sdrf.tsv",
       "path": "datasets/PXD003531/PXD003531.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003531/PXD003531.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003531/PXD003531.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003531/PXD003531.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003531/PXD003531.sdrf.tsv",
       "num_samples": 59,
       "num_columns": 36,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "high grade serous ovarian cancer",
-        "epithelial ovarian cancer"
+        "epithelial ovarian cancer",
+        "high grade serous ovarian cancer"
       ],
       "instruments": [
-        "Q Exactive HF-X",
-        "Q Exactive"
+        "Q Exactive",
+        "Q Exactive HF-X"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -2635,45 +2608,45 @@
       "file": "PXD003539.sdrf.tsv",
       "filename": "PXD003539.sdrf.tsv",
       "path": "datasets/PXD003539/PXD003539.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003539/PXD003539.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003539/PXD003539.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003539/PXD003539.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003539/PXD003539.sdrf.tsv",
       "num_samples": 120,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "breast carcinoma",
-        "prostate adenocarcinoma",
-        "malignant melanoma",
-        "large cell lung carcinoma",
-        "mesothelioma",
-        "breast ductal adenocarcinoma",
-        "ovarian carcinoma",
-        "breast adenocarcinoma",
-        "colon adenocarcinoma",
-        "clear cell renal carcinoma",
-        "acute lymphoblastic leukemia",
-        "melanoma",
-        "renal cell adenocarcinoma",
-        "immunoblastic large cell lymphoma",
-        "acute T lymphoblastic leukaemia",
-        "ovarian serous cystadenocarcinoma",
-        "colon carcinoma",
-        "ovarian adenocarcinoma",
-        "skin cutaneous melanoma",
-        "glioma",
-        "chronic myelogenic leukemia",
-        "promyelocytic leukemia",
         "lung carcinoma",
+        "mesothelioma",
+        "large cell lung carcinoma",
+        "promyelocytic leukemia",
+        "breast ductal adenocarcinoma",
+        "non-small cell lung carcinoma",
+        "breast carcinoma",
+        "ovarian carcinoma",
+        "acute lymphoblastic leukemia",
+        "ovarian adenocarcinoma",
         "renal cell carcinoma",
-        "plasmacytoma",
-        "renal clear cell adenocarcinoma",
-        "glioblastoma",
-        "renal adenocarcinoma",
         "renal carcinoma",
+        "renal clear cell adenocarcinoma",
+        "melanoma",
+        "clear cell renal carcinoma",
+        "prostate adenocarcinoma",
+        "immunoblastic large cell lymphoma",
+        "chronic myelogenic leukemia",
+        "colon adenocarcinoma",
+        "renal adenocarcinoma",
+        "plasmacytoma",
         "astrocytoma",
-        "non-small cell lung carcinoma"
+        "skin cutaneous melanoma",
+        "malignant melanoma",
+        "ovarian serous cystadenocarcinoma",
+        "glioma",
+        "glioblastoma",
+        "breast adenocarcinoma",
+        "colon carcinoma",
+        "acute T lymphoblastic leukaemia",
+        "renal cell adenocarcinoma"
       ],
       "instruments": [
         "TripleTOF 5600"
@@ -2691,8 +2664,8 @@
       "file": "PXD003615.sdrf.tsv",
       "filename": "PXD003615.sdrf.tsv",
       "path": "datasets/PXD003615/PXD003615.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003615/PXD003615.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003615/PXD003615.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003615/PXD003615.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003615/PXD003615.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 33,
       "organisms": [
@@ -2717,16 +2690,16 @@
       "file": "PXD003636.sdrf.tsv",
       "filename": "PXD003636.sdrf.tsv",
       "path": "datasets/PXD003636/PXD003636.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003636/PXD003636.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003636/PXD003636.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003636/PXD003636.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003636/PXD003636.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2744,8 +2717,8 @@
       "file": "PXD003668.sdrf.tsv",
       "filename": "PXD003668.sdrf.tsv",
       "path": "datasets/PXD003668/PXD003668.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003668/PXD003668.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003668/PXD003668.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003668/PXD003668.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003668/PXD003668.sdrf.tsv",
       "num_samples": 101,
       "num_columns": 30,
       "organisms": [
@@ -2770,8 +2743,8 @@
       "file": "PXD003977.sdrf.tsv",
       "filename": "PXD003977.sdrf.tsv",
       "path": "datasets/PXD003977/PXD003977.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD003977/PXD003977.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD003977/PXD003977.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD003977/PXD003977.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD003977/PXD003977.sdrf.tsv",
       "num_samples": 120,
       "num_columns": 31,
       "organisms": [
@@ -2796,16 +2769,16 @@
       "file": "PXD004132.sdrf.tsv",
       "filename": "PXD004132.sdrf.tsv",
       "path": "datasets/PXD004132/PXD004132.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004132/PXD004132.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004132/PXD004132.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004132/PXD004132.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004132/PXD004132.sdrf.tsv",
       "num_samples": 23,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "Prostate adenocarcinoma"
+        "Prostate adenocarcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive"
@@ -2823,8 +2796,8 @@
       "file": "PXD004143.sdrf.tsv",
       "filename": "PXD004143.sdrf.tsv",
       "path": "datasets/PXD004143/PXD004143.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004143/PXD004143.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004143/PXD004143.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004143/PXD004143.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004143/PXD004143.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 31,
       "organisms": [
@@ -2847,8 +2820,8 @@
       "file": "PXD004159.sdrf.tsv",
       "filename": "PXD004159.sdrf.tsv",
       "path": "datasets/PXD004159/PXD004159.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004159/PXD004159.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004159/PXD004159.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004159/PXD004159.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004159/PXD004159.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 33,
       "organisms": [
@@ -2873,16 +2846,16 @@
       "file": "PXD004242.sdrf.tsv",
       "filename": "PXD004242.sdrf.tsv",
       "path": "datasets/PXD004242/PXD004242.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004242/PXD004242.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004242/PXD004242.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004242/PXD004242.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004242/PXD004242.sdrf.tsv",
       "num_samples": 1290,
       "num_columns": 37,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "uninfected",
-        "obesity"
+        "obesity",
+        "uninfected"
       ],
       "instruments": [
         "Q Exactive HF"
@@ -2900,8 +2873,8 @@
       "file": "PXD004332.sdrf.tsv",
       "filename": "PXD004332.sdrf.tsv",
       "path": "datasets/PXD004332/PXD004332.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004332/PXD004332.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004332/PXD004332.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004332/PXD004332.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004332/PXD004332.sdrf.tsv",
       "num_samples": 61,
       "num_columns": 32,
       "organisms": [
@@ -2924,8 +2897,8 @@
       "file": "PXD004436.sdrf.tsv",
       "filename": "PXD004436.sdrf.tsv",
       "path": "datasets/PXD004436/PXD004436.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004436/PXD004436.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004436/PXD004436.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004436/PXD004436.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004436/PXD004436.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 24,
       "organisms": [
@@ -2935,8 +2908,8 @@
         "none"
       ],
       "instruments": [
-        "Q Exactive Plus",
-        "LTQ Velos"
+        "LTQ Velos",
+        "Q Exactive Plus"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -2951,8 +2924,8 @@
       "file": "PXD004452-celllines.sdrf.tsv",
       "filename": "PXD004452-celllines.sdrf.tsv",
       "path": "datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004452/PXD004452-celllines.sdrf.tsv",
       "num_samples": 761,
       "num_columns": 38,
       "organisms": [
@@ -2960,10 +2933,10 @@
       ],
       "diseases": [
         "lung adenocarcinoma",
-        "colon cancer",
-        "neuroblastoma",
         "breast cancer",
-        "epithelial cervix carcinoma"
+        "epithelial cervix carcinoma",
+        "colon cancer",
+        "neuroblastoma"
       ],
       "instruments": [
         "Q Exactive"
@@ -2981,8 +2954,8 @@
       "file": "PXD004452-tissues.sdrf.tsv",
       "filename": "PXD004452-tissues.sdrf.tsv",
       "path": "datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004452/PXD004452-tissues.sdrf.tsv",
       "num_samples": 216,
       "num_columns": 35,
       "organisms": [
@@ -3005,8 +2978,8 @@
       "file": "PXD004528.sdrf.tsv",
       "filename": "PXD004528.sdrf.tsv",
       "path": "datasets/PXD004528/PXD004528.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004528/PXD004528.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004528/PXD004528.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004528/PXD004528.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004528/PXD004528.sdrf.tsv",
       "num_samples": 5,
       "num_columns": 24,
       "organisms": [
@@ -3029,8 +3002,8 @@
       "file": "PXD004603.sdrf.tsv",
       "filename": "PXD004603.sdrf.tsv",
       "path": "datasets/PXD004603/PXD004603.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004603/PXD004603.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004603/PXD004603.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004603/PXD004603.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004603/PXD004603.sdrf.tsv",
       "num_samples": 23,
       "num_columns": 26,
       "organisms": [
@@ -3053,8 +3026,8 @@
       "file": "PXD004604.sdrf.tsv",
       "filename": "PXD004604.sdrf.tsv",
       "path": "datasets/PXD004604/PXD004604.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004604/PXD004604.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004604/PXD004604.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004604/PXD004604.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004604/PXD004604.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 26,
       "organisms": [
@@ -3077,8 +3050,8 @@
       "file": "PXD004605.sdrf.tsv",
       "filename": "PXD004605.sdrf.tsv",
       "path": "datasets/PXD004605/PXD004605.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004605/PXD004605.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004605/PXD004605.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004605/PXD004605.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004605/PXD004605.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 23,
       "organisms": [
@@ -3101,8 +3074,8 @@
       "file": "PXD004613.sdrf.tsv",
       "filename": "PXD004613.sdrf.tsv",
       "path": "datasets/PXD004613/PXD004613.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004613/PXD004613.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004613/PXD004613.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004613/PXD004613.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004613/PXD004613.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 35,
       "organisms": [
@@ -3127,8 +3100,8 @@
       "file": "PXD004616.sdrf.tsv",
       "filename": "PXD004616.sdrf.tsv",
       "path": "datasets/PXD004616/PXD004616.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004616/PXD004616.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004616/PXD004616.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004616/PXD004616.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004616/PXD004616.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 27,
       "organisms": [
@@ -3151,8 +3124,8 @@
       "file": "PXD004617.sdrf.tsv",
       "filename": "PXD004617.sdrf.tsv",
       "path": "datasets/PXD004617/PXD004617.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004617/PXD004617.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004617/PXD004617.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004617/PXD004617.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004617/PXD004617.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 27,
       "organisms": [
@@ -3175,8 +3148,8 @@
       "file": "PXD004618.sdrf.tsv",
       "filename": "PXD004618.sdrf.tsv",
       "path": "datasets/PXD004618/PXD004618.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004618/PXD004618.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004618/PXD004618.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004618/PXD004618.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004618/PXD004618.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 28,
       "organisms": [
@@ -3199,8 +3172,8 @@
       "file": "PXD004624.sdrf.tsv",
       "filename": "PXD004624.sdrf.tsv",
       "path": "datasets/PXD004624/PXD004624.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004624/PXD004624.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004624/PXD004624.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004624/PXD004624.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004624/PXD004624.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 35,
       "organisms": [
@@ -3225,16 +3198,16 @@
       "file": "PXD004682.sdrf.tsv",
       "filename": "PXD004682.sdrf.tsv",
       "path": "datasets/PXD004682/PXD004682.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004682/PXD004682.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004682/PXD004682.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004682/PXD004682.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004682/PXD004682.sdrf.tsv",
       "num_samples": 192,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "squamous  cell carcinoma"
+        "squamous  cell carcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive Plus"
@@ -3252,8 +3225,8 @@
       "file": "PXD004683.sdrf.tsv",
       "filename": "PXD004683.sdrf.tsv",
       "path": "datasets/PXD004683/PXD004683.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004683/PXD004683.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004683/PXD004683.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004683/PXD004683.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004683/PXD004683.sdrf.tsv",
       "num_samples": 192,
       "num_columns": 29,
       "organisms": [
@@ -3278,16 +3251,16 @@
       "file": "PXD004684.sdrf.tsv",
       "filename": "PXD004684.sdrf.tsv",
       "path": "datasets/PXD004684/PXD004684.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004684/PXD004684.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004684/PXD004684.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004684/PXD004684.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004684/PXD004684.sdrf.tsv",
       "num_samples": 16,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "control",
-        "squamous cell carcinoma"
+        "squamous cell carcinoma",
+        "control"
       ],
       "instruments": [
         "Q Exactive Plus"
@@ -3305,8 +3278,8 @@
       "file": "PXD004705.sdrf.tsv",
       "filename": "PXD004705.sdrf.tsv",
       "path": "datasets/PXD004705/PXD004705.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004705/PXD004705.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004705/PXD004705.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004705/PXD004705.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004705/PXD004705.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 28,
       "organisms": [
@@ -3329,8 +3302,8 @@
       "file": "PXD004732.sdrf.tsv",
       "filename": "PXD004732.sdrf.tsv",
       "path": "datasets/PXD004732/PXD004732.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004732/PXD004732.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004732/PXD004732.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004732/PXD004732.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004732/PXD004732.sdrf.tsv",
       "num_samples": 1460,
       "num_columns": 40,
       "organisms": [
@@ -3353,8 +3326,8 @@
       "file": "PXD004903.sdrf.tsv",
       "filename": "PXD004903.sdrf.tsv",
       "path": "datasets/PXD004903/PXD004903.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004903/PXD004903.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004903/PXD004903.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004903/PXD004903.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004903/PXD004903.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 29,
       "organisms": [
@@ -3379,8 +3352,8 @@
       "file": "PXD004939.sdrf.tsv",
       "filename": "PXD004939.sdrf.tsv",
       "path": "datasets/PXD004939/PXD004939.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004939/PXD004939.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004939/PXD004939.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004939/PXD004939.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004939/PXD004939.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 27,
       "organisms": [
@@ -3403,8 +3376,8 @@
       "file": "PXD004987.sdrf.tsv",
       "filename": "PXD004987.sdrf.tsv",
       "path": "datasets/PXD004987/PXD004987.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD004987/PXD004987.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD004987/PXD004987.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD004987/PXD004987.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD004987/PXD004987.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 25,
       "organisms": [
@@ -3427,8 +3400,8 @@
       "file": "PXD005163.sdrf.tsv",
       "filename": "PXD005163.sdrf.tsv",
       "path": "datasets/PXD005163/PXD005163.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005163/PXD005163.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005163/PXD005163.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005163/PXD005163.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005163/PXD005163.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 30,
       "organisms": [
@@ -3453,8 +3426,8 @@
       "file": "PXD005171.sdrf.tsv",
       "filename": "PXD005171.sdrf.tsv",
       "path": "datasets/PXD005171/PXD005171.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005171/PXD005171.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005171/PXD005171.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005171/PXD005171.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005171/PXD005171.sdrf.tsv",
       "num_samples": 100,
       "num_columns": 31,
       "organisms": [
@@ -3479,8 +3452,8 @@
       "file": "PXD005172.sdrf.tsv",
       "filename": "PXD005172.sdrf.tsv",
       "path": "datasets/PXD005172/PXD005172.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005172/PXD005172.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005172/PXD005172.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005172/PXD005172.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005172/PXD005172.sdrf.tsv",
       "num_samples": 100,
       "num_columns": 31,
       "organisms": [
@@ -3505,16 +3478,16 @@
       "file": "PXD005173.sdrf.tsv",
       "filename": "PXD005173.sdrf.tsv",
       "path": "datasets/PXD005173/PXD005173.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005173/PXD005173.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005173/PXD005173.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005173/PXD005173.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005173/PXD005173.sdrf.tsv",
       "num_samples": 59,
       "num_columns": 28,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "Colorectal cancer",
-        "Normal Colorectum"
+        "Normal Colorectum",
+        "Colorectal cancer"
       ],
       "instruments": [
         "LTQ Orbitrap Velos"
@@ -3532,8 +3505,8 @@
       "file": "PXD005174.sdrf.tsv",
       "filename": "PXD005174.sdrf.tsv",
       "path": "datasets/PXD005174/PXD005174.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005174/PXD005174.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005174/PXD005174.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005174/PXD005174.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005174/PXD005174.sdrf.tsv",
       "num_samples": 128,
       "num_columns": 33,
       "organisms": [
@@ -3558,8 +3531,8 @@
       "file": "PXD005175.sdrf.tsv",
       "filename": "PXD005175.sdrf.tsv",
       "path": "datasets/PXD005175/PXD005175.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005175/PXD005175.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005175/PXD005175.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005175/PXD005175.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005175/PXD005175.sdrf.tsv",
       "num_samples": 120,
       "num_columns": 29,
       "organisms": [
@@ -3584,8 +3557,8 @@
       "file": "PXD005176.sdrf.tsv",
       "filename": "PXD005176.sdrf.tsv",
       "path": "datasets/PXD005176/PXD005176.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005176/PXD005176.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005176/PXD005176.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005176/PXD005176.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005176/PXD005176.sdrf.tsv",
       "num_samples": 114,
       "num_columns": 31,
       "organisms": [
@@ -3610,8 +3583,8 @@
       "file": "PXD005177.sdrf.tsv",
       "filename": "PXD005177.sdrf.tsv",
       "path": "datasets/PXD005177/PXD005177.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005177/PXD005177.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005177/PXD005177.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005177/PXD005177.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005177/PXD005177.sdrf.tsv",
       "num_samples": 136,
       "num_columns": 32,
       "organisms": [
@@ -3636,8 +3609,8 @@
       "file": "PXD005207.sdrf.tsv",
       "filename": "PXD005207.sdrf.tsv",
       "path": "datasets/PXD005207/PXD005207.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005207/PXD005207.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005207/PXD005207.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005207/PXD005207.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005207/PXD005207.sdrf.tsv",
       "num_samples": 258,
       "num_columns": 34,
       "organisms": [
@@ -3660,8 +3633,8 @@
       "file": "PXD005241.sdrf.tsv",
       "filename": "PXD005241.sdrf.tsv",
       "path": "datasets/PXD005241/PXD005241.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005241/PXD005241.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005241/PXD005241.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005241/PXD005241.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005241/PXD005241.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 29,
       "organisms": [
@@ -3684,8 +3657,8 @@
       "file": "PXD005300.sdrf.tsv",
       "filename": "PXD005300.sdrf.tsv",
       "path": "datasets/PXD005300/PXD005300.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005300/PXD005300.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005300/PXD005300.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005300/PXD005300.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005300/PXD005300.sdrf.tsv",
       "num_samples": 128,
       "num_columns": 30,
       "organisms": [
@@ -3708,8 +3681,8 @@
       "file": "PXD005354.sdrf.tsv",
       "filename": "PXD005354.sdrf.tsv",
       "path": "datasets/PXD005354/PXD005354.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005354/PXD005354.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005354/PXD005354.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005354/PXD005354.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005354/PXD005354.sdrf.tsv",
       "num_samples": 1560,
       "num_columns": 30,
       "organisms": [
@@ -3734,8 +3707,8 @@
       "file": "PXD005355.sdrf.tsv",
       "filename": "PXD005355.sdrf.tsv",
       "path": "datasets/PXD005355/PXD005355.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005355/PXD005355.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005355/PXD005355.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005355/PXD005355.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005355/PXD005355.sdrf.tsv",
       "num_samples": 195,
       "num_columns": 30,
       "organisms": [
@@ -3760,8 +3733,8 @@
       "file": "PXD005366-hela.sdrf.tsv",
       "filename": "PXD005366-hela.sdrf.tsv",
       "path": "datasets/PXD005366/PXD005366-hela.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005366/PXD005366-hela.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005366/PXD005366-hela.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005366/PXD005366-hela.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005366/PXD005366-hela.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 39,
       "organisms": [
@@ -3786,8 +3759,8 @@
       "file": "PXD005366-rattus.sdrf.tsv",
       "filename": "PXD005366-rattus.sdrf.tsv",
       "path": "datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005366/PXD005366-rattus.sdrf.tsv",
       "num_samples": 28,
       "num_columns": 39,
       "organisms": [
@@ -3810,8 +3783,8 @@
       "file": "PXD005366.sdrf.tsv",
       "filename": "PXD005366.sdrf.tsv",
       "path": "datasets/PXD005366/PXD005366.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005366/PXD005366.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005366/PXD005366.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005366/PXD005366.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005366/PXD005366.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 39,
       "organisms": [
@@ -3836,8 +3809,8 @@
       "file": "PXD005445.sdrf.tsv",
       "filename": "PXD005445.sdrf.tsv",
       "path": "datasets/PXD005445/PXD005445.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005445/PXD005445.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005445/PXD005445.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005445/PXD005445.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005445/PXD005445.sdrf.tsv",
       "num_samples": 196,
       "num_columns": 35,
       "organisms": [
@@ -3862,8 +3835,8 @@
       "file": "PXD005463.sdrf.tsv",
       "filename": "PXD005463.sdrf.tsv",
       "path": "datasets/PXD005463/PXD005463.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005463/PXD005463.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005463/PXD005463.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005463/PXD005463.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005463/PXD005463.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 29,
       "organisms": [
@@ -3886,8 +3859,8 @@
       "file": "PXD005507.sdrf.tsv",
       "filename": "PXD005507.sdrf.tsv",
       "path": "datasets/PXD005507/PXD005507.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005507/PXD005507.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005507/PXD005507.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005507/PXD005507.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005507/PXD005507.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 32,
       "organisms": [
@@ -3912,16 +3885,16 @@
       "file": "PXD005539.sdrf.tsv",
       "filename": "PXD005539.sdrf.tsv",
       "path": "datasets/PXD005539/PXD005539.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005539/PXD005539.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005539/PXD005539.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005539/PXD005539.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005539/PXD005539.sdrf.tsv",
       "num_samples": 27,
       "num_columns": 30,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "amelanotic melanoma",
-        "malignant melanoma"
+        "malignant melanoma",
+        "amelanotic melanoma"
       ],
       "instruments": [
         " Orbitrap Elite"
@@ -3939,16 +3912,16 @@
       "file": "PXD005554.sdrf.tsv",
       "filename": "PXD005554.sdrf.tsv",
       "path": "datasets/PXD005554/PXD005554.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005554/PXD005554.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005554/PXD005554.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005554/PXD005554.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005554/PXD005554.sdrf.tsv",
       "num_samples": 142,
       "num_columns": 39,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "triple-negative breast cancer",
-        "metastatic ovarian high grade serous adenocarcinoma"
+        "metastatic ovarian high grade serous adenocarcinoma",
+        "triple-negative breast cancer"
       ],
       "instruments": [
         "Q Exactive"
@@ -3966,8 +3939,8 @@
       "file": "PXD005780.sdrf.tsv",
       "filename": "PXD005780.sdrf.tsv",
       "path": "datasets/PXD005780/PXD005780.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005780/PXD005780.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005780/PXD005780.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005780/PXD005780.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005780/PXD005780.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 31,
       "organisms": [
@@ -3990,8 +3963,8 @@
       "file": "PXD005819.sdrf.tsv",
       "filename": "PXD005819.sdrf.tsv",
       "path": "datasets/PXD005819/PXD005819.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005819/PXD005819.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005819/PXD005819.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005819/PXD005819.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005819/PXD005819.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 33,
       "organisms": [
@@ -4014,23 +3987,23 @@
       "file": "PXD005940.sdrf.tsv",
       "filename": "PXD005940.sdrf.tsv",
       "path": "datasets/PXD005940/PXD005940.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005940/PXD005940.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005940/PXD005940.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005940/PXD005940.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005940/PXD005940.sdrf.tsv",
       "num_samples": 216,
       "num_columns": 36,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "colon adenocarcinoma",
+        "astrocytoma",
         "prostate carcinoma",
         "invasive ductal carcinoma",
         "amelanotic melanoma",
+        "non-small cell lung adenocarcinoma",
         "childhood T acute lymphoblastic leukemia",
         "renal cell carcinoma",
-        "astrocytoma",
         "ovarian serous cystadenocarcinoma",
-        "non-small cell lung adenocarcinoma"
+        "colon adenocarcinoma"
       ],
       "instruments": [
         "Orbitrap Elite"
@@ -4048,42 +4021,42 @@
       "file": "PXD005942.sdrf.tsv",
       "filename": "PXD005942.sdrf.tsv",
       "path": "datasets/PXD005942/PXD005942.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005942/PXD005942.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005942/PXD005942.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005942/PXD005942.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005942/PXD005942.sdrf.tsv",
       "num_samples": 59,
       "num_columns": 31,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "prostate carcinoma",
-        "adult acute myeloid leukemia",
-        "breast adenocarcinoma",
-        "colon adenocarcinoma",
-        "childhood T acute lymphoblastic leukemia",
-        "Colon adenocarcinoma",
-        "clear cell renal carcinoma",
-        "melanoma",
-        "chronic myelogenous leukemia",
-        "Pleural Epithelioid Mesothelioma",
-        "metastatic melanoma",
-        "anaplastic large cell lymphoma",
-        "adult T acute lymphoblastic leukemia",
-        "ovarian serous cystadenocarcinoma",
-        "non-small cell lung adenocarcinoma",
-        "colon carcinoma",
-        "renal cell carcinoma",
-        "brain glioblastoma",
-        "gliosarcoma",
         "cutaneous melanoma",
         "multiple myeloma",
+        "metastatic melanoma",
+        "adult T acute lymphoblastic leukemia",
+        "non-small cell lung carcinoma",
+        "Pleural Epithelioid Mesothelioma",
         "lung adenocarcinoma",
         "invasive ductal carcinoma",
-        "amelanotic melanoma",
+        "non-small cell lung adenocarcinoma",
+        "renal cell carcinoma",
         "high grade ovarian serous adenocarcinoma",
+        "brain glioblastoma",
+        "gliosarcoma",
+        "adult acute myeloid leukemia",
+        "melanoma",
+        "prostate carcinoma",
+        "clear cell renal carcinoma",
+        "childhood T acute lymphoblastic leukemia",
+        "colon adenocarcinoma",
         "astrocytoma",
-        "non-small cell lung carcinoma",
-        "Ovarian Endometrioid Adenocarcinoma"
+        "amelanotic melanoma",
+        "ovarian serous cystadenocarcinoma",
+        "breast adenocarcinoma",
+        "anaplastic large cell lymphoma",
+        "Colon adenocarcinoma",
+        "colon carcinoma",
+        "Ovarian Endometrioid Adenocarcinoma",
+        "chronic myelogenous leukemia"
       ],
       "instruments": [
         "LTQ Orbitrap XL ETD"
@@ -4101,42 +4074,42 @@
       "file": "PXD005946.sdrf.tsv",
       "filename": "PXD005946.sdrf.tsv",
       "path": "datasets/PXD005946/PXD005946.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD005946/PXD005946.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD005946/PXD005946.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD005946/PXD005946.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD005946/PXD005946.sdrf.tsv",
       "num_samples": 732,
       "num_columns": 35,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "prostate carcinoma",
-        "adult acute myeloid leukemia",
-        "breast adenocarcinoma",
-        "colon adenocarcinoma",
-        "childhood T acute lymphoblastic leukemia",
-        "clear cell renal carcinoma",
-        "rectosigmoid adenocarcinoma",
-        "melanoma",
-        "chronic myelogenous leukemia",
-        "Pleural Epithelioid Mesothelioma",
-        "metastatic melanoma",
-        "anaplastic large cell lymphoma",
-        "adult T acute lymphoblastic leukemia",
-        "ovarian serous cystadenocarcinoma",
-        "non-small cell lung adenocarcinoma",
-        "colon carcinoma",
-        "renal cell carcinoma",
-        "brain glioblastoma",
-        "gliosarcoma",
         "cutaneous melanoma",
         "multiple myeloma",
-        "invasive ductal carcinoma",
-        "lung adenocarcinoma",
-        "amelanotic melanoma",
-        "high grade ovarian serous adenocarcinoma",
-        "astrocytoma",
+        "metastatic melanoma",
+        "Pleural Epithelioid Mesothelioma",
         "non-small cell lung carcinoma",
-        "Ovarian Endometrioid Adenocarcinoma"
+        "adult T acute lymphoblastic leukemia",
+        "lung adenocarcinoma",
+        "invasive ductal carcinoma",
+        "non-small cell lung adenocarcinoma",
+        "renal cell carcinoma",
+        "brain glioblastoma",
+        "high grade ovarian serous adenocarcinoma",
+        "gliosarcoma",
+        "adult acute myeloid leukemia",
+        "melanoma",
+        "prostate carcinoma",
+        "rectosigmoid adenocarcinoma",
+        "clear cell renal carcinoma",
+        "childhood T acute lymphoblastic leukemia",
+        "colon adenocarcinoma",
+        "astrocytoma",
+        "amelanotic melanoma",
+        "ovarian serous cystadenocarcinoma",
+        "breast adenocarcinoma",
+        "anaplastic large cell lymphoma",
+        "colon carcinoma",
+        "Ovarian Endometrioid Adenocarcinoma",
+        "chronic myelogenous leukemia"
       ],
       "instruments": [
         "LTQ Orbitrap XL ETD"
@@ -4154,8 +4127,8 @@
       "file": "PXD006003.sdrf.tsv",
       "filename": "PXD006003.sdrf.tsv",
       "path": "datasets/PXD006003/PXD006003.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006003/PXD006003.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006003/PXD006003.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006003/PXD006003.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006003/PXD006003.sdrf.tsv",
       "num_samples": 1346,
       "num_columns": 37,
       "organisms": [
@@ -4180,8 +4153,8 @@
       "file": "PXD006132.sdrf.tsv",
       "filename": "PXD006132.sdrf.tsv",
       "path": "datasets/PXD006132/PXD006132.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006132/PXD006132.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006132/PXD006132.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006132/PXD006132.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006132/PXD006132.sdrf.tsv",
       "num_samples": 49,
       "num_columns": 36,
       "organisms": [
@@ -4206,8 +4179,8 @@
       "file": "PXD006195.sdrf.tsv",
       "filename": "PXD006195.sdrf.tsv",
       "path": "datasets/PXD006195/PXD006195.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006195/PXD006195.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006195/PXD006195.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006195/PXD006195.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006195/PXD006195.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 36,
       "organisms": [
@@ -4230,8 +4203,8 @@
       "file": "PXD006233.sdrf.tsv",
       "filename": "PXD006233.sdrf.tsv",
       "path": "datasets/PXD006233/PXD006233.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006233/PXD006233.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006233/PXD006233.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006233/PXD006233.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006233/PXD006233.sdrf.tsv",
       "num_samples": 378,
       "num_columns": 29,
       "organisms": [
@@ -4256,13 +4229,13 @@
       "file": "PXD006401.sdrf.tsv",
       "filename": "PXD006401.sdrf.tsv",
       "path": "datasets/PXD006401/PXD006401.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006401/PXD006401.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006401/PXD006401.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006401/PXD006401.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006401/PXD006401.sdrf.tsv",
       "num_samples": 28,
       "num_columns": 32,
       "organisms": [
-        "homo sapiens",
-        "mus musculus"
+        "mus musculus",
+        "homo sapiens"
       ],
       "diseases": [],
       "instruments": [
@@ -4281,8 +4254,8 @@
       "file": "PXD006430-silac.sdrf.tsv",
       "filename": "PXD006430-silac.sdrf.tsv",
       "path": "datasets/PXD006430/PXD006430-silac.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006430/PXD006430-silac.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006430/PXD006430-silac.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006430/PXD006430-silac.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006430/PXD006430-silac.sdrf.tsv",
       "num_samples": 576,
       "num_columns": 36,
       "organisms": [
@@ -4292,8 +4265,8 @@
         "breast cancer"
       ],
       "instruments": [
-        "LTQ Orbitrap Velos",
-        "Q Exactive"
+        "Q Exactive",
+        "LTQ Orbitrap Velos"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -4308,8 +4281,8 @@
       "file": "PXD006430-tmt.sdrf.tsv",
       "filename": "PXD006430-tmt.sdrf.tsv",
       "path": "datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006430/PXD006430-tmt.sdrf.tsv",
       "num_samples": 720,
       "num_columns": 32,
       "organisms": [
@@ -4334,8 +4307,8 @@
       "file": "PXD006482.sdrf.tsv",
       "filename": "PXD006482.sdrf.tsv",
       "path": "datasets/PXD006482/PXD006482.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006482/PXD006482.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006482/PXD006482.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006482/PXD006482.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006482/PXD006482.sdrf.tsv",
       "num_samples": 192,
       "num_columns": 36,
       "organisms": [
@@ -4360,8 +4333,8 @@
       "file": "PXD006542.sdrf.tsv",
       "filename": "PXD006542.sdrf.tsv",
       "path": "datasets/PXD006542/PXD006542.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006542/PXD006542.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006542/PXD006542.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006542/PXD006542.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006542/PXD006542.sdrf.tsv",
       "num_samples": 1488,
       "num_columns": 30,
       "organisms": [
@@ -4386,8 +4359,8 @@
       "file": "PXD006607.sdrf.tsv",
       "filename": "PXD006607.sdrf.tsv",
       "path": "datasets/PXD006607/PXD006607.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006607/PXD006607.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006607/PXD006607.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006607/PXD006607.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006607/PXD006607.sdrf.tsv",
       "num_samples": 1028,
       "num_columns": 37,
       "organisms": [
@@ -4412,8 +4385,8 @@
       "file": "PXD006675.sdrf.tsv",
       "filename": "PXD006675.sdrf.tsv",
       "path": "datasets/PXD006675/PXD006675.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006675/PXD006675.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006675/PXD006675.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006675/PXD006675.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006675/PXD006675.sdrf.tsv",
       "num_samples": 594,
       "num_columns": 30,
       "organisms": [
@@ -4439,8 +4412,8 @@
       "file": "PXD006877.sdrf.tsv",
       "filename": "PXD006877.sdrf.tsv",
       "path": "datasets/PXD006877/PXD006877.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006877/PXD006877.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006877/PXD006877.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006877/PXD006877.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006877/PXD006877.sdrf.tsv",
       "num_samples": 112,
       "num_columns": 25,
       "organisms": [
@@ -4463,8 +4436,8 @@
       "file": "PXD006914.sdrf.tsv",
       "filename": "PXD006914.sdrf.tsv",
       "path": "datasets/PXD006914/PXD006914.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD006914/PXD006914.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD006914/PXD006914.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD006914/PXD006914.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD006914/PXD006914.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 29,
       "organisms": [
@@ -4491,8 +4464,8 @@
       "file": "PXD007073.sdrf.tsv",
       "filename": "PXD007073.sdrf.tsv",
       "path": "datasets/PXD007073/PXD007073.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007073/PXD007073.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007073/PXD007073.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007073/PXD007073.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007073/PXD007073.sdrf.tsv",
       "num_samples": 136,
       "num_columns": 35,
       "organisms": [
@@ -4517,49 +4490,49 @@
       "file": "PXD007160.sdrf.tsv",
       "filename": "PXD007160.sdrf.tsv",
       "path": "datasets/PXD007160/PXD007160.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007160/PXD007160.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007160/PXD007160.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007160/PXD007160.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007160/PXD007160.sdrf.tsv",
       "num_samples": 1687,
       "num_columns": 32,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "Alzheimer's disease/Parkinson's disease6",
-        "Alzheimer's disease/Parkinson's disease",
-        "Alzheimer's disease 7",
-        "control3",
-        "Alzheimer's disease0",
         "Alzheimer's disease 8",
-        "Alzheimer's disease",
-        "Parkinson's disease",
-        "control6",
-        "control8",
-        "Parkinson's disease0",
-        "Alzheimer's disease/Parkinson's disease9",
-        "Parkinson's disease3",
-        "Alzheimer's disease 5",
-        "control7",
-        "Alzheimer's disease/Parkinson's disease8",
-        "Alzheimer's disease/Parkinson's disease5",
-        "Alzheimer's disease/Parkinson's disease7",
-        "Parkinson's disease9",
-        "Alzheimer's disease 3",
-        "Parkinson's disease7",
+        "Alzheimer's disease 6",
+        "Alzheimer's disease 4",
         "Alzheimer's disease/Parkinson's disease4",
+        "control6",
+        "Alzheimer's disease",
+        "Alzheimer's disease/Parkinson's disease8",
+        "Alzheimer's disease/Parkinson's disease7",
+        "Alzheimer's disease/Parkinson's disease0",
+        "Alzheimer's disease 5",
+        "Alzheimer's disease/Parkinson's disease6",
+        "control",
+        "Alzheimer's disease 7",
+        "Alzheimer's disease 3",
+        "Parkinson's disease3",
+        "Alzheimer's disease0",
+        "Alzheimer's disease/Parkinson's disease3",
         "Alzheimer's disease 9",
-        "control0",
+        "control5",
+        "Alzheimer's disease/Parkinson's disease",
+        "Parkinson's disease9",
+        "Parkinson's disease7",
+        "Alzheimer's disease/Parkinson's disease9",
+        "Alzheimer's disease/Parkinson's disease5",
+        "Parkinson's disease0",
         "Parkinson's disease4",
         "Parkinson's disease5",
-        "Alzheimer's disease/Parkinson's disease0",
-        "control4",
-        "Alzheimer's disease 4",
-        "Alzheimer's disease/Parkinson's disease3",
         "control9",
-        "control",
-        "Alzheimer's disease 6",
-        "control5",
+        "control0",
+        "control4",
+        "Parkinson's disease",
         "Parkinson's disease8",
+        "control3",
+        "control8",
+        "control7",
         "Parkinson's disease6"
       ],
       "instruments": [
@@ -4578,8 +4551,8 @@
       "file": "PXD007555.sdrf.tsv",
       "filename": "PXD007555.sdrf.tsv",
       "path": "datasets/PXD007555/PXD007555.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007555/PXD007555.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007555/PXD007555.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007555/PXD007555.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007555/PXD007555.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 30,
       "organisms": [
@@ -4604,8 +4577,8 @@
       "file": "PXD007662.sdrf.tsv",
       "filename": "PXD007662.sdrf.tsv",
       "path": "datasets/PXD007662/PXD007662.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007662/PXD007662.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007662/PXD007662.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007662/PXD007662.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007662/PXD007662.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 35,
       "organisms": [
@@ -4630,8 +4603,8 @@
       "file": "PXD007864.sdrf.tsv",
       "filename": "PXD007864.sdrf.tsv",
       "path": "datasets/PXD007864/PXD007864.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD007864/PXD007864.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD007864/PXD007864.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD007864/PXD007864.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD007864/PXD007864.sdrf.tsv",
       "num_samples": 2,
       "num_columns": 31,
       "organisms": [
@@ -4654,8 +4627,8 @@
       "file": "PXD008012.sdrf.tsv",
       "filename": "PXD008012.sdrf.tsv",
       "path": "datasets/PXD008012/PXD008012.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008012/PXD008012.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008012/PXD008012.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008012/PXD008012.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008012/PXD008012.sdrf.tsv",
       "num_samples": 141,
       "num_columns": 40,
       "organisms": [
@@ -4680,22 +4653,22 @@
       "file": "PXD008222.sdrf.tsv",
       "filename": "PXD008222.sdrf.tsv",
       "path": "datasets/PXD008222/PXD008222.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008222/PXD008222.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008222/PXD008222.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008222/PXD008222.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008222/PXD008222.sdrf.tsv",
       "num_samples": 456,
       "num_columns": 32,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "breast carcinoma",
         "fibrocystic disease",
-        "medulallary carcinoma",
         "primary breast tumor",
         "primary ductal carcinoma",
+        "medulallary carcinoma",
         "ductal carcinoma",
-        "metastatic carcinoma",
-        "primary acantholytic squamous cell carcinoma"
+        "primary acantholytic squamous cell carcinoma",
+        "breast carcinoma",
+        "metastatic carcinoma"
       ],
       "instruments": [
         "Q Exactive"
@@ -4713,8 +4686,8 @@
       "file": "PXD008355.sdrf.tsv",
       "filename": "PXD008355.sdrf.tsv",
       "path": "datasets/PXD008355/PXD008355.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008355/PXD008355.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008355/PXD008355.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008355/PXD008355.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008355/PXD008355.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 35,
       "organisms": [
@@ -4737,8 +4710,8 @@
       "file": "PXD008369.sdrf.tsv",
       "filename": "PXD008369.sdrf.tsv",
       "path": "datasets/PXD008369/PXD008369.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008369/PXD008369.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008369/PXD008369.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008369/PXD008369.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008369/PXD008369.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 36,
       "organisms": [
@@ -4761,8 +4734,8 @@
       "file": "PXD008440.sdrf.tsv",
       "filename": "PXD008440.sdrf.tsv",
       "path": "datasets/PXD008440/PXD008440.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008440/PXD008440.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008440/PXD008440.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008440/PXD008440.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008440/PXD008440.sdrf.tsv",
       "num_samples": 200,
       "num_columns": 32,
       "organisms": [
@@ -4787,8 +4760,8 @@
       "file": "PXD008722.sdrf.tsv",
       "filename": "PXD008722.sdrf.tsv",
       "path": "datasets/PXD008722/PXD008722.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008722/PXD008722.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008722/PXD008722.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008722/PXD008722.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008722/PXD008722.sdrf.tsv",
       "num_samples": 252,
       "num_columns": 30,
       "organisms": [
@@ -4813,8 +4786,8 @@
       "file": "PXD008840.sdrf.tsv",
       "filename": "PXD008840.sdrf.tsv",
       "path": "datasets/PXD008840/PXD008840.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008840/PXD008840.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008840/PXD008840.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008840/PXD008840.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008840/PXD008840.sdrf.tsv",
       "num_samples": 1016,
       "num_columns": 34,
       "organisms": [
@@ -4839,20 +4812,20 @@
       "file": "PXD008841.sdrf.tsv",
       "filename": "PXD008841.sdrf.tsv",
       "path": "datasets/PXD008841/PXD008841.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008841/PXD008841.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008841/PXD008841.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008841/PXD008841.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008841/PXD008841.sdrf.tsv",
       "num_samples": 3600,
       "num_columns": 31,
       "organisms": [
         "Homo Sapiens"
       ],
       "diseases": [
+        "breast cancer",
+        "basal-like breast carcinoma",
         "luminal A breast carcinoma",
         "luminal B breast carcinoma",
-        "HER2 Positive Breast Carcinoma",
         "Normal Breast-Like Subtype of Breast Carcinoma",
-        "basal-like breast carcinoma",
-        "breast cancer"
+        "HER2 Positive Breast Carcinoma"
       ],
       "instruments": [
         "Q Exactive"
@@ -4870,8 +4843,8 @@
       "file": "PXD008921.sdrf.tsv",
       "filename": "PXD008921.sdrf.tsv",
       "path": "datasets/PXD008921/PXD008921.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008921/PXD008921.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008921/PXD008921.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008921/PXD008921.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008921/PXD008921.sdrf.tsv",
       "num_samples": 36,
       "num_columns": 35,
       "organisms": [
@@ -4894,18 +4867,18 @@
       "file": "PXD008934.sdrf.tsv",
       "filename": "PXD008934.sdrf.tsv",
       "path": "datasets/PXD008934/PXD008934.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD008934/PXD008934.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD008934/PXD008934.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD008934/PXD008934.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD008934/PXD008934.sdrf.tsv",
       "num_samples": 34,
       "num_columns": 29,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "dilated cardiomyopathy",
         "ischemic cardiomyopathy",
-        "compensated hypertrophy",
-        "cardiac hypertrophy"
+        "dilated cardiomyopathy",
+        "cardiac hypertrophy",
+        "compensated hypertrophy"
       ],
       "instruments": [
         "Q Exactive"
@@ -4923,8 +4896,8 @@
       "file": "PXD009157.sdrf.tsv",
       "filename": "PXD009157.sdrf.tsv",
       "path": "datasets/PXD009157/PXD009157.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009157/PXD009157.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009157/PXD009157.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009157/PXD009157.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009157/PXD009157.sdrf.tsv",
       "num_samples": 66,
       "num_columns": 29,
       "organisms": [
@@ -4947,8 +4920,8 @@
       "file": "PXD009203.sdrf.tsv",
       "filename": "PXD009203.sdrf.tsv",
       "path": "datasets/PXD009203/PXD009203.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009203/PXD009203.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009203/PXD009203.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009203/PXD009203.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009203/PXD009203.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 29,
       "organisms": [
@@ -4974,8 +4947,8 @@
       "file": "PXD009465.sdrf.tsv",
       "filename": "PXD009465.sdrf.tsv",
       "path": "datasets/PXD009465/PXD009465.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009465/PXD009465.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009465/PXD009465.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009465/PXD009465.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009465/PXD009465.sdrf.tsv",
       "num_samples": 60,
       "num_columns": 29,
       "organisms": [
@@ -4998,8 +4971,8 @@
       "file": "PXD009602.sdrf.tsv",
       "filename": "PXD009602.sdrf.tsv",
       "path": "datasets/PXD009602/PXD009602.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009602/PXD009602.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009602/PXD009602.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009602/PXD009602.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009602/PXD009602.sdrf.tsv",
       "num_samples": 528,
       "num_columns": 33,
       "organisms": [
@@ -5024,8 +4997,8 @@
       "file": "PXD009623-dda.sdrf.tsv",
       "filename": "PXD009623-dda.sdrf.tsv",
       "path": "datasets/PXD009623/PXD009623-dda.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009623/PXD009623-dda.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009623/PXD009623-dda.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009623/PXD009623-dda.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009623/PXD009623-dda.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 27,
       "organisms": [
@@ -5048,8 +5021,8 @@
       "file": "PXD009623-dia.sdrf.tsv",
       "filename": "PXD009623-dia.sdrf.tsv",
       "path": "datasets/PXD009623/PXD009623-dia.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009623/PXD009623-dia.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009623/PXD009623-dia.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009623/PXD009623-dia.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009623/PXD009623-dia.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 27,
       "organisms": [
@@ -5072,8 +5045,8 @@
       "file": "PXD009630.sdrf.tsv",
       "filename": "PXD009630.sdrf.tsv",
       "path": "datasets/PXD009630/PXD009630.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009630/PXD009630.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009630/PXD009630.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009630/PXD009630.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009630/PXD009630.sdrf.tsv",
       "num_samples": 111,
       "num_columns": 29,
       "organisms": [
@@ -5082,15 +5055,15 @@
       "diseases": [
         "other",
         "superficial spreading melanoma",
-        "acral lentiginous melanoma",
-        "unknown",
-        "lentigo maligna melanoma",
         "mucosal",
-        "nodular melanoma"
+        "acral lentiginous melanoma",
+        "nodular melanoma",
+        "unknown",
+        "lentigo maligna melanoma"
       ],
       "instruments": [
-        "Q Exactive Plus",
-        "Q Exactive"
+        "Q Exactive",
+        "Q Exactive Plus"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -5105,8 +5078,8 @@
       "file": "PXD009815.sdrf.tsv",
       "filename": "PXD009815.sdrf.tsv",
       "path": "datasets/PXD009815/PXD009815.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009815/PXD009815.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009815/PXD009815.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009815/PXD009815.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009815/PXD009815.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 27,
       "organisms": [
@@ -5129,8 +5102,8 @@
       "file": "PXD009909.sdrf.tsv",
       "filename": "PXD009909.sdrf.tsv",
       "path": "datasets/PXD009909/PXD009909.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD009909/PXD009909.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD009909/PXD009909.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD009909/PXD009909.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD009909/PXD009909.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 27,
       "organisms": [
@@ -5153,8 +5126,8 @@
       "file": "PXD010154.sdrf.tsv",
       "filename": "PXD010154.sdrf.tsv",
       "path": "datasets/PXD010154/PXD010154.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010154/PXD010154.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010154/PXD010154.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010154/PXD010154.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010154/PXD010154.sdrf.tsv",
       "num_samples": 1800,
       "num_columns": 32,
       "organisms": [
@@ -5163,8 +5136,8 @@
       "diseases": [],
       "instruments": [
         "Orbitrap Fusion Lumos",
-        "Q Exactive Plus",
-        "Q Exactive HF"
+        "Q Exactive HF",
+        "Q Exactive Plus"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -5179,8 +5152,8 @@
       "file": "PXD010271.sdrf.tsv",
       "filename": "PXD010271.sdrf.tsv",
       "path": "datasets/PXD010271/PXD010271.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010271/PXD010271.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010271/PXD010271.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010271/PXD010271.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010271/PXD010271.sdrf.tsv",
       "num_samples": 252,
       "num_columns": 30,
       "organisms": [
@@ -5190,8 +5163,8 @@
         "Disease"
       ],
       "instruments": [
-        "LTQ Orbitrap Velos",
-        "Q Exactive"
+        "Q Exactive",
+        "LTQ Orbitrap Velos"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -5206,8 +5179,8 @@
       "file": "PXD010357.sdrf.tsv",
       "filename": "PXD010357.sdrf.tsv",
       "path": "datasets/PXD010357/PXD010357.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010357/PXD010357.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010357/PXD010357.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010357/PXD010357.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010357/PXD010357.sdrf.tsv",
       "num_samples": 116,
       "num_columns": 27,
       "organisms": [
@@ -5232,22 +5205,22 @@
       "file": "PXD010371.sdrf.tsv",
       "filename": "PXD010371.sdrf.tsv",
       "path": "datasets/PXD010371/PXD010371.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010371/PXD010371.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010371/PXD010371.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010371/PXD010371.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010371/PXD010371.sdrf.tsv",
       "num_samples": 77,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
+        "Gastric Carcinoma",
+        "Healthy control",
         "Ulcerative Colitis active stage",
         "Irritable Bowel Syndrome",
-        "Healthy control",
-        "Colon Adenoma",
-        "Ulcerative Colitis remission stage",
         "'Crohn''s Disease Irritable Bowel Syndrome'",
-        "'Crohn''s Disease'",
-        "Gastric Carcinoma"
+        "Ulcerative Colitis remission stage",
+        "Colon Adenoma",
+        "'Crohn''s Disease'"
       ],
       "instruments": [
         "Q Exactive HF"
@@ -5265,8 +5238,8 @@
       "file": "PXD010429.sdrf.tsv",
       "filename": "PXD010429.sdrf.tsv",
       "path": "datasets/PXD010429/PXD010429.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010429/PXD010429.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010429/PXD010429.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010429/PXD010429.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010429/PXD010429.sdrf.tsv",
       "num_samples": 4176,
       "num_columns": 34,
       "organisms": [
@@ -5291,8 +5264,8 @@
       "file": "PXD010595.sdrf.tsv",
       "filename": "PXD010595.sdrf.tsv",
       "path": "datasets/PXD010595/PXD010595.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010595/PXD010595.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010595/PXD010595.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010595/PXD010595.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010595/PXD010595.sdrf.tsv",
       "num_samples": 888,
       "num_columns": 40,
       "organisms": [
@@ -5315,8 +5288,8 @@
       "file": "PXD010603.sdrf.tsv",
       "filename": "PXD010603.sdrf.tsv",
       "path": "datasets/PXD010603/PXD010603.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010603/PXD010603.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010603/PXD010603.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010603/PXD010603.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010603/PXD010603.sdrf.tsv",
       "num_samples": 311,
       "num_columns": 35,
       "organisms": [
@@ -5341,8 +5314,8 @@
       "file": "PXD010698.sdrf.tsv",
       "filename": "PXD010698.sdrf.tsv",
       "path": "datasets/PXD010698/PXD010698.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010698/PXD010698.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010698/PXD010698.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010698/PXD010698.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010698/PXD010698.sdrf.tsv",
       "num_samples": 5,
       "num_columns": 27,
       "organisms": [
@@ -5367,8 +5340,8 @@
       "file": "PXD010705.sdrf.tsv",
       "filename": "PXD010705.sdrf.tsv",
       "path": "datasets/PXD010705/PXD010705.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010705/PXD010705.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010705/PXD010705.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010705/PXD010705.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010705/PXD010705.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 26,
       "organisms": [
@@ -5393,8 +5366,8 @@
       "file": "PXD010708.sdrf.tsv",
       "filename": "PXD010708.sdrf.tsv",
       "path": "datasets/PXD010708/PXD010708.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010708/PXD010708.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010708/PXD010708.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010708/PXD010708.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010708/PXD010708.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 27,
       "organisms": [
@@ -5419,8 +5392,8 @@
       "file": "PXD010981.sdrf.tsv",
       "filename": "PXD010981.sdrf.tsv",
       "path": "datasets/PXD010981/PXD010981.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD010981/PXD010981.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD010981/PXD010981.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD010981/PXD010981.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD010981/PXD010981.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 36,
       "organisms": [
@@ -5443,8 +5416,8 @@
       "file": "PXD011023.sdrf.tsv",
       "filename": "PXD011023.sdrf.tsv",
       "path": "datasets/PXD011023/PXD011023.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011023/PXD011023.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011023/PXD011023.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011023/PXD011023.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011023/PXD011023.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 36,
       "organisms": [
@@ -5467,8 +5440,8 @@
       "file": "PXD011050.sdrf.tsv",
       "filename": "PXD011050.sdrf.tsv",
       "path": "datasets/PXD011050/PXD011050.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011050/PXD011050.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011050/PXD011050.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011050/PXD011050.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011050/PXD011050.sdrf.tsv",
       "num_samples": 16,
       "num_columns": 24,
       "organisms": [
@@ -5491,8 +5464,8 @@
       "file": "PXD011153.sdrf.tsv",
       "filename": "PXD011153.sdrf.tsv",
       "path": "datasets/PXD011153/PXD011153.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011153/PXD011153.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011153/PXD011153.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011153/PXD011153.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011153/PXD011153.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 26,
       "organisms": [
@@ -5517,8 +5490,8 @@
       "file": "PXD011175.sdrf.tsv",
       "filename": "PXD011175.sdrf.tsv",
       "path": "datasets/PXD011175/PXD011175.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011175/PXD011175.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011175/PXD011175.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011175/PXD011175.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011175/PXD011175.sdrf.tsv",
       "num_samples": 28,
       "num_columns": 37,
       "organisms": [
@@ -5543,8 +5516,8 @@
       "file": "PXD011799.sdrf.tsv",
       "filename": "PXD011799.sdrf.tsv",
       "path": "datasets/PXD011799/PXD011799.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011799/PXD011799.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011799/PXD011799.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011799/PXD011799.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011799/PXD011799.sdrf.tsv",
       "num_samples": 480,
       "num_columns": 35,
       "organisms": [
@@ -5569,17 +5542,17 @@
       "file": "PXD011839.sdrf.tsv",
       "filename": "PXD011839.sdrf.tsv",
       "path": "datasets/PXD011839/PXD011839.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011839/PXD011839.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011839/PXD011839.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011839/PXD011839.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011839/PXD011839.sdrf.tsv",
       "num_samples": 399,
       "num_columns": 38,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
+        "cirrhosis of liver",
         "type II diabetes mellitus",
-        "non-alcoholic fatty liver disease",
-        "cirrhosis of liver"
+        "non-alcoholic fatty liver disease"
       ],
       "instruments": [
         "Q Exactive HF-X"
@@ -5597,8 +5570,8 @@
       "file": "PXD011967.sdrf.tsv",
       "filename": "PXD011967.sdrf.tsv",
       "path": "datasets/PXD011967/PXD011967.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD011967/PXD011967.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD011967/PXD011967.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD011967/PXD011967.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD011967/PXD011967.sdrf.tsv",
       "num_samples": 2316,
       "num_columns": 31,
       "organisms": [
@@ -5621,16 +5594,16 @@
       "file": "PXD012131.sdrf.tsv",
       "filename": "PXD012131.sdrf.tsv",
       "path": "datasets/PXD012131/PXD012131.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012131/PXD012131.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012131/PXD012131.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012131/PXD012131.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012131/PXD012131.sdrf.tsv",
       "num_samples": 326,
       "num_columns": 37,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "Alzheimer's disease (stage III)",
-        "Alzheimer's disease (stage VI)"
+        "Alzheimer's disease (stage VI)",
+        "Alzheimer's disease (stage III)"
       ],
       "instruments": [
         "Orbitrap Fusion Lumos"
@@ -5648,8 +5621,8 @@
       "file": "PXD012143.sdrf.tsv",
       "filename": "PXD012143.sdrf.tsv",
       "path": "datasets/PXD012143/PXD012143.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012143/PXD012143.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012143/PXD012143.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012143/PXD012143.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012143/PXD012143.sdrf.tsv",
       "num_samples": 320,
       "num_columns": 30,
       "organisms": [
@@ -5672,8 +5645,8 @@
       "file": "PXD012203.sdrf.tsv",
       "filename": "PXD012203.sdrf.tsv",
       "path": "datasets/PXD012203/PXD012203.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012203/PXD012203.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012203/PXD012203.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012203/PXD012203.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012203/PXD012203.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 31,
       "organisms": [
@@ -5681,8 +5654,8 @@
       ],
       "diseases": [
         "Non-demented control",
-        "Alzheimer's diseasemedial",
-        "Alzheimer's disease"
+        "Alzheimer's disease",
+        "Alzheimer's diseasemedial"
       ],
       "instruments": [
         "Q Exactive"
@@ -5700,8 +5673,8 @@
       "file": "PXD012243.sdrf.tsv",
       "filename": "PXD012243.sdrf.tsv",
       "path": "datasets/PXD012243/PXD012243.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012243/PXD012243.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012243/PXD012243.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012243/PXD012243.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012243/PXD012243.sdrf.tsv",
       "num_samples": 128,
       "num_columns": 37,
       "organisms": [
@@ -5726,8 +5699,8 @@
       "file": "PXD012255.sdrf.tsv",
       "filename": "PXD012255.sdrf.tsv",
       "path": "datasets/PXD012255/PXD012255.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012255/PXD012255.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012255/PXD012255.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012255/PXD012255.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012255/PXD012255.sdrf.tsv",
       "num_samples": 40,
       "num_columns": 32,
       "organisms": [
@@ -5752,8 +5725,8 @@
       "file": "PXD012277.sdrf.tsv",
       "filename": "PXD012277.sdrf.tsv",
       "path": "datasets/PXD012277/PXD012277.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012277/PXD012277.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012277/PXD012277.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012277/PXD012277.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012277/PXD012277.sdrf.tsv",
       "num_samples": 42,
       "num_columns": 37,
       "organisms": [
@@ -5776,8 +5749,8 @@
       "file": "PXD012307.sdrf.tsv",
       "filename": "PXD012307.sdrf.tsv",
       "path": "datasets/PXD012307/PXD012307.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012307/PXD012307.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012307/PXD012307.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012307/PXD012307.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012307/PXD012307.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 28,
       "organisms": [
@@ -5800,8 +5773,8 @@
       "file": "PXD012431.sdrf.tsv",
       "filename": "PXD012431.sdrf.tsv",
       "path": "datasets/PXD012431/PXD012431.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012431/PXD012431.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012431/PXD012431.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012431/PXD012431.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012431/PXD012431.sdrf.tsv",
       "num_samples": 69,
       "num_columns": 31,
       "organisms": [
@@ -5826,8 +5799,8 @@
       "file": "PXD012593-rat.sdrf.tsv",
       "filename": "PXD012593-rat.sdrf.tsv",
       "path": "datasets/PXD012593/PXD012593-rat.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012593/PXD012593-rat.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012593/PXD012593-rat.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012593/PXD012593-rat.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012593/PXD012593-rat.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 22,
       "organisms": [
@@ -5850,8 +5823,8 @@
       "file": "PXD012593-srm.sdrf.tsv",
       "filename": "PXD012593-srm.sdrf.tsv",
       "path": "datasets/PXD012593/PXD012593-srm.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012593/PXD012593-srm.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012593/PXD012593-srm.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012593/PXD012593-srm.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012593/PXD012593-srm.sdrf.tsv",
       "num_samples": 55,
       "num_columns": 26,
       "organisms": [
@@ -5859,8 +5832,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Q Exactive Plus",
-        "TSQ Quantiva"
+        "TSQ Quantiva",
+        "Q Exactive Plus"
       ],
       "acquisition_methods": [
         "selected reaction monitoring"
@@ -5875,8 +5848,8 @@
       "file": "PXD012611.sdrf.tsv",
       "filename": "PXD012611.sdrf.tsv",
       "path": "datasets/PXD012611/PXD012611.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012611/PXD012611.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012611/PXD012611.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012611/PXD012611.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012611/PXD012611.sdrf.tsv",
       "num_samples": 34,
       "num_columns": 34,
       "organisms": [
@@ -5899,8 +5872,8 @@
       "file": "PXD012755.sdrf.tsv",
       "filename": "PXD012755.sdrf.tsv",
       "path": "datasets/PXD012755/PXD012755.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012755/PXD012755.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012755/PXD012755.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012755/PXD012755.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012755/PXD012755.sdrf.tsv",
       "num_samples": 32,
       "num_columns": 29,
       "organisms": [
@@ -5926,8 +5899,8 @@
       "file": "PXD012764.sdrf.tsv",
       "filename": "PXD012764.sdrf.tsv",
       "path": "datasets/PXD012764/PXD012764.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012764/PXD012764.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012764/PXD012764.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012764/PXD012764.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012764/PXD012764.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 26,
       "organisms": [
@@ -5950,8 +5923,8 @@
       "file": "PXD012923.sdrf.tsv",
       "filename": "PXD012923.sdrf.tsv",
       "path": "datasets/PXD012923/PXD012923.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012923/PXD012923.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012923/PXD012923.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012923/PXD012923.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012923/PXD012923.sdrf.tsv",
       "num_samples": 78,
       "num_columns": 37,
       "organisms": [
@@ -5976,8 +5949,8 @@
       "file": "PXD012986.sdrf.tsv",
       "filename": "PXD012986.sdrf.tsv",
       "path": "datasets/PXD012986/PXD012986.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD012986/PXD012986.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD012986/PXD012986.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD012986/PXD012986.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD012986/PXD012986.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 43,
       "organisms": [
@@ -6000,16 +5973,16 @@
       "file": "PXD013234.sdrf.tsv",
       "filename": "PXD013234.sdrf.tsv",
       "path": "datasets/PXD013234/PXD013234.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013234/PXD013234.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013234/PXD013234.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013234/PXD013234.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013234/PXD013234.sdrf.tsv",
       "num_samples": 54,
       "num_columns": 33,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "uninfected",
-        "polycythemia vera"
+        "polycythemia vera",
+        "uninfected"
       ],
       "instruments": [
         "Q Exactive HF-X"
@@ -6027,8 +6000,8 @@
       "file": "PXD013273.sdrf.tsv",
       "filename": "PXD013273.sdrf.tsv",
       "path": "datasets/PXD013273/PXD013273.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013273/PXD013273.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013273/PXD013273.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013273/PXD013273.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013273/PXD013273.sdrf.tsv",
       "num_samples": 28,
       "num_columns": 30,
       "organisms": [
@@ -6051,8 +6024,8 @@
       "file": "PXD013523.sdrf.tsv",
       "filename": "PXD013523.sdrf.tsv",
       "path": "datasets/PXD013523/PXD013523.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013523/PXD013523.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013523/PXD013523.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013523/PXD013523.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013523/PXD013523.sdrf.tsv",
       "num_samples": 198,
       "num_columns": 35,
       "organisms": [
@@ -6077,8 +6050,8 @@
       "file": "PXD013610.sdrf.tsv",
       "filename": "PXD013610.sdrf.tsv",
       "path": "datasets/PXD013610/PXD013610.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013610/PXD013610.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013610/PXD013610.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013610/PXD013610.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013610/PXD013610.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 31,
       "organisms": [
@@ -6101,8 +6074,8 @@
       "file": "PXD013737.sdrf.tsv",
       "filename": "PXD013737.sdrf.tsv",
       "path": "datasets/PXD013737/PXD013737.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013737/PXD013737.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013737/PXD013737.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013737/PXD013737.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013737/PXD013737.sdrf.tsv",
       "num_samples": 96,
       "num_columns": 35,
       "organisms": [
@@ -6125,16 +6098,16 @@
       "file": "PXD013753.sdrf.tsv",
       "filename": "PXD013753.sdrf.tsv",
       "path": "datasets/PXD013753/PXD013753.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013753/PXD013753.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013753/PXD013753.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013753/PXD013753.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013753/PXD013753.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 37,
       "organisms": [
         "homo sapiens"
       ],
       "diseases": [
-        "Control",
-        "Alzheimer's Disease"
+        "Alzheimer's Disease",
+        "Control"
       ],
       "instruments": [
         "Q Exactive HF"
@@ -6152,8 +6125,8 @@
       "file": "PXD013765.sdrf.tsv",
       "filename": "PXD013765.sdrf.tsv",
       "path": "datasets/PXD013765/PXD013765.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013765/PXD013765.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013765/PXD013765.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013765/PXD013765.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013765/PXD013765.sdrf.tsv",
       "num_samples": 144,
       "num_columns": 34,
       "organisms": [
@@ -6178,8 +6151,8 @@
       "file": "PXD013868.sdrf.tsv",
       "filename": "PXD013868.sdrf.tsv",
       "path": "datasets/PXD013868/PXD013868.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013868/PXD013868.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013868/PXD013868.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013868/PXD013868.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013868/PXD013868.sdrf.tsv",
       "num_samples": 1560,
       "num_columns": 30,
       "organisms": [
@@ -6202,8 +6175,8 @@
       "file": "PXD013923.sdrf.tsv",
       "filename": "PXD013923.sdrf.tsv",
       "path": "datasets/PXD013923/PXD013923.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD013923/PXD013923.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD013923/PXD013923.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD013923/PXD013923.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD013923/PXD013923.sdrf.tsv",
       "num_samples": 372,
       "num_columns": 39,
       "organisms": [
@@ -6228,8 +6201,8 @@
       "file": "PXD014058.sdrf.tsv",
       "filename": "PXD014058.sdrf.tsv",
       "path": "datasets/PXD014058/PXD014058.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014058/PXD014058.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014058/PXD014058.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014058/PXD014058.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014058/PXD014058.sdrf.tsv",
       "num_samples": 323,
       "num_columns": 31,
       "organisms": [
@@ -6238,8 +6211,8 @@
       "diseases": [
         "Hepatoblastoma",
         "Colorectal cancer",
-        "gastric carcinoma",
-        "epithelial cervix carcinoma"
+        "epithelial cervix carcinoma",
+        "gastric carcinoma"
       ],
       "instruments": [
         "Orbitrap Fusion Lumos"
@@ -6257,8 +6230,8 @@
       "file": "PXD014145.sdrf.tsv",
       "filename": "PXD014145.sdrf.tsv",
       "path": "datasets/PXD014145/PXD014145.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014145/PXD014145.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014145/PXD014145.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014145/PXD014145.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014145/PXD014145.sdrf.tsv",
       "num_samples": 132,
       "num_columns": 33,
       "organisms": [
@@ -6283,8 +6256,8 @@
       "file": "PXD14458.sdrf.tsv",
       "filename": "PXD14458.sdrf.tsv",
       "path": "datasets/PXD014458/PXD14458.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014458/PXD14458.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014458/PXD14458.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014458/PXD14458.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014458/PXD14458.sdrf.tsv",
       "num_samples": 44,
       "num_columns": 29,
       "organisms": [
@@ -6310,8 +6283,8 @@
       "file": "PXD014502.sdrf.tsv",
       "filename": "PXD014502.sdrf.tsv",
       "path": "datasets/PXD014502/PXD014502.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014502/PXD014502.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014502/PXD014502.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014502/PXD014502.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014502/PXD014502.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 23,
       "organisms": [
@@ -6334,8 +6307,8 @@
       "file": "PXD014525-dda.sdrf.tsv",
       "filename": "PXD014525-dda.sdrf.tsv",
       "path": "datasets/PXD014525/PXD014525-dda.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014525/PXD014525-dda.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014525/PXD014525-dda.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014525/PXD014525-dda.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014525/PXD014525-dda.sdrf.tsv",
       "num_samples": 224,
       "num_columns": 38,
       "organisms": [
@@ -6361,8 +6334,8 @@
       "file": "PXD014525-dia.sdrf.tsv",
       "filename": "PXD014525-dia.sdrf.tsv",
       "path": "datasets/PXD014525/PXD014525-dia.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014525/PXD014525-dia.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014525/PXD014525-dia.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014525/PXD014525-dia.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014525/PXD014525-dia.sdrf.tsv",
       "num_samples": 427,
       "num_columns": 35,
       "organisms": [
@@ -6388,8 +6361,8 @@
       "file": "PXD014528.sdrf.tsv",
       "filename": "PXD014528.sdrf.tsv",
       "path": "datasets/PXD014528/PXD014528.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014528/PXD014528.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014528/PXD014528.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014528/PXD014528.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014528/PXD014528.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 29,
       "organisms": [
@@ -6412,8 +6385,8 @@
       "file": "PXD014557.sdrf.tsv",
       "filename": "PXD014557.sdrf.tsv",
       "path": "datasets/PXD014557/PXD014557.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014557/PXD014557.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014557/PXD014557.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014557/PXD014557.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014557/PXD014557.sdrf.tsv",
       "num_samples": 400,
       "num_columns": 34,
       "organisms": [
@@ -6438,8 +6411,8 @@
       "file": "PXD014565.sdrf.tsv",
       "filename": "PXD014565.sdrf.tsv",
       "path": "datasets/PXD014565/PXD014565.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD014565/PXD014565.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD014565/PXD014565.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD014565/PXD014565.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD014565/PXD014565.sdrf.tsv",
       "num_samples": 80,
       "num_columns": 33,
       "organisms": [
@@ -6464,8 +6437,8 @@
       "file": "PXD015093-LFQ.sdrf.tsv",
       "filename": "PXD015093-LFQ.sdrf.tsv",
       "path": "datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015093/PXD015093-LFQ.sdrf.tsv",
       "num_samples": 148,
       "num_columns": 29,
       "organisms": [
@@ -6488,8 +6461,8 @@
       "file": "PXD015093-TMT.sdrf.tsv",
       "filename": "PXD015093-TMT.sdrf.tsv",
       "path": "datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015093/PXD015093-TMT.sdrf.tsv",
       "num_samples": 1380,
       "num_columns": 32,
       "organisms": [
@@ -6512,8 +6485,8 @@
       "file": "PXD015270.sdrf.tsv",
       "filename": "PXD015270.sdrf.tsv",
       "path": "datasets/PXD015270/PXD015270.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015270/PXD015270.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015270/PXD015270.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015270/PXD015270.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015270/PXD015270.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 33,
       "organisms": [
@@ -6539,8 +6512,8 @@
       "file": "PXD015578.sdrf.tsv",
       "filename": "PXD015578.sdrf.tsv",
       "path": "datasets/PXD015578/PXD015578.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015578/PXD015578.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015578/PXD015578.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015578/PXD015578.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015578/PXD015578.sdrf.tsv",
       "num_samples": 34,
       "num_columns": 32,
       "organisms": [
@@ -6563,8 +6536,8 @@
       "file": "PXD015744.sdrf.tsv",
       "filename": "PXD015744.sdrf.tsv",
       "path": "datasets/PXD015744/PXD015744.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015744/PXD015744.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015744/PXD015744.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015744/PXD015744.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015744/PXD015744.sdrf.tsv",
       "num_samples": 100,
       "num_columns": 32,
       "organisms": [
@@ -6589,19 +6562,19 @@
       "file": "PXD015833-Exp1.sdrf.tsv",
       "filename": "PXD015833-Exp1.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp1.sdrf.tsv",
       "num_samples": 360,
       "num_columns": 32,
       "organisms": [
         "Homo sapiens",
-        "plasmodium knowlesi",
-        "plasmodium falciparum"
+        "plasmodium falciparum",
+        "plasmodium knowlesi"
       ],
       "diseases": [],
       "instruments": [
-        "Orbitrap Fusion Lumos",
-        "Q Exactive"
+        "Q Exactive",
+        "Orbitrap Fusion Lumos"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -6616,8 +6589,8 @@
       "file": "PXD015833-Exp2.sdrf.tsv",
       "filename": "PXD015833-Exp2.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp2.sdrf.tsv",
       "num_samples": 120,
       "num_columns": 33,
       "organisms": [
@@ -6641,8 +6614,8 @@
       "file": "PXD015833-Exp3.sdrf.tsv",
       "filename": "PXD015833-Exp3.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp3.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 31,
       "organisms": [
@@ -6665,13 +6638,13 @@
       "file": "PXD015833-Exp4.sdrf.tsv",
       "filename": "PXD015833-Exp4.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp4.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 31,
       "organisms": [
-        "plasmodium knowlesi",
-        "plasmodium falciparum"
+        "plasmodium falciparum",
+        "plasmodium knowlesi"
       ],
       "diseases": [],
       "instruments": [
@@ -6690,13 +6663,13 @@
       "file": "PXD015833-Exp5.sdrf.tsv",
       "filename": "PXD015833-Exp5.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp5.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 31,
       "organisms": [
-        "plasmodium knowlesi",
-        "plasmodium falciparum"
+        "plasmodium falciparum",
+        "plasmodium knowlesi"
       ],
       "diseases": [],
       "instruments": [
@@ -6715,13 +6688,13 @@
       "file": "PXD015833-Exp6.sdrf.tsv",
       "filename": "PXD015833-Exp6.sdrf.tsv",
       "path": "datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015833/PXD015833-Exp6.sdrf.tsv",
       "num_samples": 160,
       "num_columns": 31,
       "organisms": [
-        "plasmodium knowlesi",
-        "plasmodium falciparum"
+        "plasmodium falciparum",
+        "plasmodium knowlesi"
       ],
       "diseases": [],
       "instruments": [
@@ -6740,16 +6713,16 @@
       "file": "PXD015957.sdrf.tsv",
       "filename": "PXD015957.sdrf.tsv",
       "path": "datasets/PXD015957/PXD015957.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD015957/PXD015957.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD015957/PXD015957.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD015957/PXD015957.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD015957/PXD015957.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 36,
       "organisms": [
         "Homo sapiens"
       ],
       "diseases": [
-        "metastatic melanoma tumor",
-        "malignant melanoma"
+        "malignant melanoma",
+        "metastatic melanoma tumor"
       ],
       "instruments": [
         " Q Exactive Plus"
@@ -6767,8 +6740,8 @@
       "file": "PXD016001.sdrf.tsv",
       "filename": "PXD016001.sdrf.tsv",
       "path": "datasets/PXD016001/PXD016001.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016001/PXD016001.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016001/PXD016001.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016001/PXD016001.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016001/PXD016001.sdrf.tsv",
       "num_samples": 61,
       "num_columns": 32,
       "organisms": [
@@ -6791,8 +6764,8 @@
       "file": "PXD016002.sdrf.tsv",
       "filename": "PXD016002.sdrf.tsv",
       "path": "datasets/PXD016002/PXD016002.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016002/PXD016002.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016002/PXD016002.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016002/PXD016002.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016002/PXD016002.sdrf.tsv",
       "num_samples": 1008,
       "num_columns": 34,
       "organisms": [
@@ -6817,8 +6790,8 @@
       "file": "PXD016074.sdrf.tsv",
       "filename": "PXD016074.sdrf.tsv",
       "path": "datasets/PXD016074/PXD016074.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016074/PXD016074.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016074/PXD016074.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016074/PXD016074.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016074/PXD016074.sdrf.tsv",
       "num_samples": 24,
       "num_columns": 33,
       "organisms": [
@@ -6841,8 +6814,8 @@
       "file": "PXD016669.sdrf.tsv",
       "filename": "PXD016669.sdrf.tsv",
       "path": "datasets/PXD016669/PXD016669.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016669/PXD016669.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016669/PXD016669.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016669/PXD016669.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016669/PXD016669.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 34,
       "organisms": [
@@ -6850,8 +6823,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Orbitrap Velos Pro",
-        "Q Exactive Plus"
+        "Q Exactive Plus",
+        "Orbitrap Velos Pro"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -6866,8 +6839,8 @@
       "file": "PXD016772.sdrf.tsv",
       "filename": "PXD016772.sdrf.tsv",
       "path": "datasets/PXD016772/PXD016772.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016772/PXD016772.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016772/PXD016772.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016772/PXD016772.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016772/PXD016772.sdrf.tsv",
       "num_samples": 22,
       "num_columns": 30,
       "organisms": [
@@ -6890,8 +6863,8 @@
       "file": "PXD016837.sdrf.tsv",
       "filename": "PXD016837.sdrf.tsv",
       "path": "datasets/PXD016837/PXD016837.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD016837/PXD016837.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD016837/PXD016837.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD016837/PXD016837.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD016837/PXD016837.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 32,
       "organisms": [
@@ -6916,19 +6889,19 @@
       "file": "PXD017035.sdrf.tsv",
       "filename": "PXD017035.sdrf.tsv",
       "path": "datasets/PXD017035/PXD017035.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017035/PXD017035.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017035/PXD017035.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017035/PXD017035.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017035/PXD017035.sdrf.tsv",
       "num_samples": 720,
       "num_columns": 30,
       "organisms": [
-        "clostridium",
-        "Blautia producta",
-        "Anaerostipes caccae",
         "lactobacillus",
-        "Escherichia coli K-12",
-        "Clostridium butyricum",
         "Bifidobacterium longum",
-        "Bacteroides thetaiotaomicron"
+        "Anaerostipes caccae",
+        "Bacteroides thetaiotaomicron",
+        "clostridium",
+        "Clostridium butyricum",
+        "Escherichia coli K-12",
+        "Blautia producta"
       ],
       "diseases": [],
       "instruments": [
@@ -6947,8 +6920,8 @@
       "file": "PXD017201.sdrf.tsv",
       "filename": "PXD017201.sdrf.tsv",
       "path": "datasets/PXD017201/PXD017201.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017201/PXD017201.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017201/PXD017201.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017201/PXD017201.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017201/PXD017201.sdrf.tsv",
       "num_samples": 3600,
       "num_columns": 39,
       "organisms": [
@@ -6973,8 +6946,8 @@
       "file": "PXD017291-mixed-label.sdrf.tsv",
       "filename": "PXD017291-mixed-label.sdrf.tsv",
       "path": "datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017291/PXD017291-mixed-label.sdrf.tsv",
       "num_samples": 1584,
       "num_columns": 40,
       "organisms": [
@@ -7000,8 +6973,8 @@
       "file": "PXD017291-tmt.sdrf.tsv",
       "filename": "PXD017291-tmt.sdrf.tsv",
       "path": "datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017291/PXD017291-tmt.sdrf.tsv",
       "num_samples": 600,
       "num_columns": 38,
       "organisms": [
@@ -7026,8 +6999,8 @@
       "file": "PXD017602.sdrf.tsv",
       "filename": "PXD017602.sdrf.tsv",
       "path": "datasets/PXD017602/PXD017602.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017602/PXD017602.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017602/PXD017602.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017602/PXD017602.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017602/PXD017602.sdrf.tsv",
       "num_samples": 64,
       "num_columns": 18,
       "organisms": [
@@ -7052,8 +7025,8 @@
       "file": "PXD017618.sdrf.tsv",
       "filename": "PXD017618.sdrf.tsv",
       "path": "datasets/PXD017618/PXD017618.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017618/PXD017618.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017618/PXD017618.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017618/PXD017618.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017618/PXD017618.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 31,
       "organisms": [
@@ -7077,8 +7050,8 @@
       "file": "PXD017710-silac.sdrf.tsv",
       "filename": "PXD017710-silac.sdrf.tsv",
       "path": "datasets/PXD017710/PXD017710-silac.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017710/PXD017710-silac.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017710/PXD017710-silac.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017710/PXD017710-silac.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017710/PXD017710-silac.sdrf.tsv",
       "num_samples": 264,
       "num_columns": 38,
       "organisms": [
@@ -7104,8 +7077,8 @@
       "file": "PXD017710-tmt.sdrf.tsv",
       "filename": "PXD017710-tmt.sdrf.tsv",
       "path": "datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD017710/PXD017710-tmt.sdrf.tsv",
       "num_samples": 216,
       "num_columns": 35,
       "organisms": [
@@ -7130,8 +7103,8 @@
       "file": "PXD018117.sdrf.tsv",
       "filename": "PXD018117.sdrf.tsv",
       "path": "datasets/PXD018117/PXD018117.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018117/PXD018117.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018117/PXD018117.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018117/PXD018117.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018117/PXD018117.sdrf.tsv",
       "num_samples": 98,
       "num_columns": 33,
       "organisms": [
@@ -7154,8 +7127,8 @@
       "file": "PXD018241-phosphoproteomics.sdrf.tsv",
       "filename": "PXD018241-phosphoproteomics.sdrf.tsv",
       "path": "datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018241/PXD018241-phosphoproteomics.sdrf.tsv",
       "num_samples": 2,
       "num_columns": 32,
       "organisms": [
@@ -7178,8 +7151,8 @@
       "file": "PXD018241.sdrf.tsv",
       "filename": "PXD018241.sdrf.tsv",
       "path": "datasets/PXD018241/PXD018241.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018241/PXD018241.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018241/PXD018241.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018241/PXD018241.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018241/PXD018241.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 31,
       "organisms": [
@@ -7202,8 +7175,8 @@
       "file": "PXD018357.sdrf.tsv",
       "filename": "PXD018357.sdrf.tsv",
       "path": "datasets/PXD018357/PXD018357.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018357/PXD018357.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018357/PXD018357.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018357/PXD018357.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018357/PXD018357.sdrf.tsv",
       "num_samples": 240,
       "num_columns": 33,
       "organisms": [
@@ -7229,8 +7202,8 @@
       "file": "PXD018581.sdrf.tsv",
       "filename": "PXD018581.sdrf.tsv",
       "path": "datasets/PXD018581/PXD018581.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018581/PXD018581.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018581/PXD018581.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018581/PXD018581.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018581/PXD018581.sdrf.tsv",
       "num_samples": 481,
       "num_columns": 37,
       "organisms": [
@@ -7255,8 +7228,8 @@
       "file": "PXD018594.sdrf.tsv",
       "filename": "PXD018594.sdrf.tsv",
       "path": "datasets/PXD018594/PXD018594.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018594/PXD018594.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018594/PXD018594.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018594/PXD018594.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018594/PXD018594.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 34,
       "organisms": [
@@ -7279,8 +7252,8 @@
       "file": "PXD018678-dda.sdrf.tsv",
       "filename": "PXD018678-dda.sdrf.tsv",
       "path": "datasets/PXD018678/PXD018678-dda.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018678/PXD018678-dda.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018678/PXD018678-dda.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018678/PXD018678-dda.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018678/PXD018678-dda.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 33,
       "organisms": [
@@ -7305,8 +7278,8 @@
       "file": "PXD018678-dia.sdrf.tsv",
       "filename": "PXD018678-dia.sdrf.tsv",
       "path": "datasets/PXD018678/PXD018678-dia.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018678/PXD018678-dia.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018678/PXD018678-dia.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018678/PXD018678-dia.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018678/PXD018678-dia.sdrf.tsv",
       "num_samples": 46,
       "num_columns": 33,
       "organisms": [
@@ -7331,8 +7304,8 @@
       "file": "PXD018830-DIA.sdrf.tsv",
       "filename": "PXD018830-DIA.sdrf.tsv",
       "path": "datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018830/PXD018830-DIA.sdrf.tsv",
       "num_samples": 25,
       "num_columns": 32,
       "organisms": [
@@ -7358,8 +7331,8 @@
       "file": "PXD018970.sdrf.tsv",
       "filename": "PXD018970.sdrf.tsv",
       "path": "datasets/PXD018970/PXD018970.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD018970/PXD018970.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD018970/PXD018970.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD018970/PXD018970.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD018970/PXD018970.sdrf.tsv",
       "num_samples": 54,
       "num_columns": 31,
       "organisms": [
@@ -7384,8 +7357,8 @@
       "file": "PXD019113.sdrf.tsv",
       "filename": "PXD019113.sdrf.tsv",
       "path": "datasets/PXD019113/PXD019113.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019113/PXD019113.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019113/PXD019113.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019113/PXD019113.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019113/PXD019113.sdrf.tsv",
       "num_samples": 64,
       "num_columns": 34,
       "organisms": [
@@ -7409,8 +7382,8 @@
       "file": "PXD019123.sdrf.tsv",
       "filename": "PXD019123.sdrf.tsv",
       "path": "datasets/PXD019123/PXD019123.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019123/PXD019123.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019123/PXD019123.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019123/PXD019123.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019123/PXD019123.sdrf.tsv",
       "num_samples": 99,
       "num_columns": 32,
       "organisms": [
@@ -7435,8 +7408,8 @@
       "file": "PXD019140.sdrf.tsv",
       "filename": "PXD019140.sdrf.tsv",
       "path": "datasets/PXD019140/PXD019140.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019140/PXD019140.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019140/PXD019140.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019140/PXD019140.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019140/PXD019140.sdrf.tsv",
       "num_samples": 21,
       "num_columns": 26,
       "organisms": [
@@ -7459,8 +7432,8 @@
       "file": "PXD019185_PXD018883.sdrf.tsv",
       "filename": "PXD019185_PXD018883.sdrf.tsv",
       "path": "datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019185_PXD018883/PXD019185_PXD018883.sdrf.tsv",
       "num_samples": 13,
       "num_columns": 41,
       "organisms": [
@@ -7485,8 +7458,8 @@
       "file": "PXD019288.sdrf.tsv",
       "filename": "PXD019288.sdrf.tsv",
       "path": "datasets/PXD019288/PXD019288.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019288/PXD019288.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019288/PXD019288.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019288/PXD019288.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019288/PXD019288.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 34,
       "organisms": [
@@ -7509,8 +7482,8 @@
       "file": "PXD019291.sdrf.tsv",
       "filename": "PXD019291.sdrf.tsv",
       "path": "datasets/PXD019291/PXD019291.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD019291/PXD019291.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD019291/PXD019291.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD019291/PXD019291.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD019291/PXD019291.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 28,
       "organisms": [
@@ -7533,8 +7506,8 @@
       "file": "PXD020187.sdrf.tsv",
       "filename": "PXD020187.sdrf.tsv",
       "path": "datasets/PXD020187/PXD020187.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020187/PXD020187.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020187/PXD020187.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020187/PXD020187.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020187/PXD020187.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 29,
       "organisms": [
@@ -7542,15 +7515,15 @@
       ],
       "diseases": [
         "native_5",
-        "decellularized_1",
-        "native_4",
-        "decellularized_3",
-        "native_2",
-        "native_3",
-        "native_1",
         "decellularized_4",
+        "decellularized_5",
+        "native_1",
+        "decellularized_3",
         "decellularized_2",
-        "decellularized_5"
+        "native_4",
+        "decellularized_1",
+        "native_2",
+        "native_3"
       ],
       "instruments": [
         "LTQ"
@@ -7568,8 +7541,8 @@
       "file": "PXD020192.sdrf.tsv",
       "filename": "PXD020192.sdrf.tsv",
       "path": "datasets/PXD020192/PXD020192.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020192/PXD020192.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020192/PXD020192.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020192/PXD020192.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020192/PXD020192.sdrf.tsv",
       "num_samples": 92,
       "num_columns": 30,
       "organisms": [
@@ -7594,8 +7567,8 @@
       "file": "PXD020207.sdrf.tsv",
       "filename": "PXD020207.sdrf.tsv",
       "path": "datasets/PXD020207/PXD020207.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020207/PXD020207.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020207/PXD020207.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020207/PXD020207.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020207/PXD020207.sdrf.tsv",
       "num_samples": 15,
       "num_columns": 26,
       "organisms": [
@@ -7618,8 +7591,8 @@
       "file": "PXD020249.sdrf.tsv",
       "filename": "PXD020249.sdrf.tsv",
       "path": "datasets/PXD020249/PXD020249.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020249/PXD020249.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020249/PXD020249.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020249/PXD020249.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020249/PXD020249.sdrf.tsv",
       "num_samples": 130,
       "num_columns": 39,
       "organisms": [
@@ -7642,8 +7615,8 @@
       "file": "PXD020381.sdrf.tsv",
       "filename": "PXD020381.sdrf.tsv",
       "path": "datasets/PXD020381/PXD020381.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020381/PXD020381.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020381/PXD020381.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020381/PXD020381.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020381/PXD020381.sdrf.tsv",
       "num_samples": 370,
       "num_columns": 28,
       "organisms": [
@@ -7666,8 +7639,8 @@
       "file": "PXD020394.sdrf.tsv",
       "filename": "PXD020394.sdrf.tsv",
       "path": "datasets/PXD020394/PXD020394.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020394/PXD020394.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020394/PXD020394.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020394/PXD020394.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020394/PXD020394.sdrf.tsv",
       "num_samples": 20,
       "num_columns": 30,
       "organisms": [
@@ -7692,8 +7665,8 @@
       "file": "PXD020785.sdrf.tsv",
       "filename": "PXD020785.sdrf.tsv",
       "path": "datasets/PXD020785/PXD020785.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD020785/PXD020785.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD020785/PXD020785.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD020785/PXD020785.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD020785/PXD020785.sdrf.tsv",
       "num_samples": 209,
       "num_columns": 31,
       "organisms": [
@@ -7717,8 +7690,8 @@
       "file": "PXD021874.sdrf.tsv",
       "filename": "PXD021874.sdrf.tsv",
       "path": "datasets/PXD021874/PXD021874.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD021874/PXD021874.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD021874/PXD021874.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD021874/PXD021874.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD021874/PXD021874.sdrf.tsv",
       "num_samples": 62,
       "num_columns": 24,
       "organisms": [
@@ -7741,8 +7714,8 @@
       "file": "PXD022070.sdrf.tsv",
       "filename": "PXD022070.sdrf.tsv",
       "path": "datasets/PXD022070/PXD022070.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD022070/PXD022070.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD022070/PXD022070.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD022070/PXD022070.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD022070/PXD022070.sdrf.tsv",
       "num_samples": 186,
       "num_columns": 28,
       "organisms": [
@@ -7765,8 +7738,8 @@
       "file": "PXD022526.sdrf.tsv",
       "filename": "PXD022526.sdrf.tsv",
       "path": "datasets/PXD022526/PXD022526.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD022526/PXD022526.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD022526/PXD022526.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD022526/PXD022526.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD022526/PXD022526.sdrf.tsv",
       "num_samples": 9,
       "num_columns": 33,
       "organisms": [
@@ -7789,8 +7762,8 @@
       "file": "PXD023158.sdrf.tsv",
       "filename": "PXD023158.sdrf.tsv",
       "path": "datasets/PXD023158/PXD023158.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD023158/PXD023158.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD023158/PXD023158.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD023158/PXD023158.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD023158/PXD023158.sdrf.tsv",
       "num_samples": 90,
       "num_columns": 33,
       "organisms": [
@@ -7813,8 +7786,8 @@
       "file": "PXD023650.sdrf.tsv",
       "filename": "PXD023650.sdrf.tsv",
       "path": "datasets/PXD023650/PXD023650.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD023650/PXD023650.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD023650/PXD023650.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD023650/PXD023650.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD023650/PXD023650.sdrf.tsv",
       "num_samples": 123,
       "num_columns": 31,
       "organisms": [
@@ -7839,8 +7812,8 @@
       "file": "PXD023707.sdrf.tsv",
       "filename": "PXD023707.sdrf.tsv",
       "path": "datasets/PXD023707/PXD023707.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD023707/PXD023707.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD023707/PXD023707.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD023707/PXD023707.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD023707/PXD023707.sdrf.tsv",
       "num_samples": 3,
       "num_columns": 36,
       "organisms": [
@@ -7865,8 +7838,8 @@
       "file": "PXD024138.sdrf.tsv",
       "filename": "PXD024138.sdrf.tsv",
       "path": "datasets/PXD024138/PXD024138.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD024138/PXD024138.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD024138/PXD024138.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD024138/PXD024138.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD024138/PXD024138.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 32,
       "organisms": [
@@ -7889,8 +7862,8 @@
       "file": "PXD025088.sdrf.tsv",
       "filename": "PXD025088.sdrf.tsv",
       "path": "datasets/PXD025088/PXD025088.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD025088/PXD025088.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD025088/PXD025088.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD025088/PXD025088.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD025088/PXD025088.sdrf.tsv",
       "num_samples": 16,
       "num_columns": 34,
       "organisms": [
@@ -7913,8 +7886,8 @@
       "file": "PXD025706.sdrf.tsv",
       "filename": "PXD025706.sdrf.tsv",
       "path": "datasets/PXD025706/PXD025706.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD025706/PXD025706.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD025706/PXD025706.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD025706/PXD025706.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD025706/PXD025706.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 34,
       "organisms": [
@@ -7922,8 +7895,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Q Exactive HF",
-        "Q Exactive"
+        "Q Exactive",
+        "Q Exactive HF"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -7938,8 +7911,8 @@
       "file": "PXD026474.sdrf.tsv",
       "filename": "PXD026474.sdrf.tsv",
       "path": "datasets/PXD026474/PXD026474.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD026474/PXD026474.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD026474/PXD026474.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD026474/PXD026474.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD026474/PXD026474.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 32,
       "organisms": [
@@ -7962,8 +7935,8 @@
       "file": "PXD029347.sdrf.tsv",
       "filename": "PXD029347.sdrf.tsv",
       "path": "datasets/PXD029347/PXD029347.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD029347/PXD029347.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD029347/PXD029347.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD029347/PXD029347.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD029347/PXD029347.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 28,
       "organisms": [
@@ -7986,8 +7959,8 @@
       "file": "PXD029931.sdrf.tsv",
       "filename": "PXD029931.sdrf.tsv",
       "path": "datasets/PXD029931/PXD029931.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD029931/PXD029931.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD029931/PXD029931.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD029931/PXD029931.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD029931/PXD029931.sdrf.tsv",
       "num_samples": 21,
       "num_columns": 34,
       "organisms": [
@@ -8010,8 +7983,8 @@
       "file": "PXD030345.sdrf.tsv",
       "filename": "PXD030345.sdrf.tsv",
       "path": "datasets/PXD030345/PXD030345.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD030345/PXD030345.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD030345/PXD030345.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD030345/PXD030345.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD030345/PXD030345.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 34,
       "organisms": [
@@ -8034,8 +8007,8 @@
       "file": "PXD030346.sdrf.tsv",
       "filename": "PXD030346.sdrf.tsv",
       "path": "datasets/PXD030346/PXD030346.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD030346/PXD030346.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD030346/PXD030346.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD030346/PXD030346.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD030346/PXD030346.sdrf.tsv",
       "num_samples": 12,
       "num_columns": 34,
       "organisms": [
@@ -8058,8 +8031,8 @@
       "file": "PXD030650.sdrf.tsv",
       "filename": "PXD030650.sdrf.tsv",
       "path": "datasets/PXD030650/PXD030650.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD030650/PXD030650.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD030650/PXD030650.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD030650/PXD030650.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD030650/PXD030650.sdrf.tsv",
       "num_samples": 60,
       "num_columns": 31,
       "organisms": [
@@ -8082,8 +8055,8 @@
       "file": "PXD030690.sdrf.tsv",
       "filename": "PXD030690.sdrf.tsv",
       "path": "datasets/PXD030690/PXD030690.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD030690/PXD030690.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD030690/PXD030690.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD030690/PXD030690.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD030690/PXD030690.sdrf.tsv",
       "num_samples": 10,
       "num_columns": 30,
       "organisms": [
@@ -8106,8 +8079,8 @@
       "file": "PXD031694.sdrf.tsv",
       "filename": "PXD031694.sdrf.tsv",
       "path": "datasets/PXD031694/PXD031694.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD031694/PXD031694.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD031694/PXD031694.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD031694/PXD031694.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD031694/PXD031694.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 27,
       "organisms": [
@@ -8130,8 +8103,8 @@
       "file": "PXD032954.sdrf.tsv",
       "filename": "PXD032954.sdrf.tsv",
       "path": "datasets/PXD032954/PXD032954.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD032954/PXD032954.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD032954/PXD032954.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD032954/PXD032954.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD032954/PXD032954.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 34,
       "organisms": [
@@ -8154,8 +8127,8 @@
       "file": "PXD035590.sdrf.tsv",
       "filename": "PXD035590.sdrf.tsv",
       "path": "datasets/PXD035590/PXD035590.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD035590/PXD035590.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD035590/PXD035590.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD035590/PXD035590.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD035590/PXD035590.sdrf.tsv",
       "num_samples": 6,
       "num_columns": 27,
       "organisms": [
@@ -8178,8 +8151,8 @@
       "file": "PXD036749.sdrf.tsv",
       "filename": "PXD036749.sdrf.tsv",
       "path": "datasets/PXD036749/PXD036749.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD036749/PXD036749.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD036749/PXD036749.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD036749/PXD036749.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD036749/PXD036749.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 30,
       "organisms": [
@@ -8202,8 +8175,8 @@
       "file": "PXD037221.sdrf.tsv",
       "filename": "PXD037221.sdrf.tsv",
       "path": "datasets/PXD037221/PXD037221.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD037221/PXD037221.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD037221/PXD037221.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD037221/PXD037221.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD037221/PXD037221.sdrf.tsv",
       "num_samples": 90,
       "num_columns": 27,
       "organisms": [
@@ -8226,8 +8199,8 @@
       "file": "PXD040621.sdrf.tsv",
       "filename": "PXD040621.sdrf.tsv",
       "path": "datasets/PXD040621/PXD040621.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD040621/PXD040621.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD040621/PXD040621.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD040621/PXD040621.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD040621/PXD040621.sdrf.tsv",
       "num_samples": 8,
       "num_columns": 29,
       "organisms": [
@@ -8250,8 +8223,8 @@
       "file": "PXD041301.sdrf.tsv",
       "filename": "PXD041301.sdrf.tsv",
       "path": "datasets/PXD041301/PXD041301.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD041301/PXD041301.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD041301/PXD041301.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD041301/PXD041301.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD041301/PXD041301.sdrf.tsv",
       "num_samples": 18,
       "num_columns": 32,
       "organisms": [
@@ -8274,8 +8247,8 @@
       "file": "PXD042173.sdrf.tsv",
       "filename": "PXD042173.sdrf.tsv",
       "path": "datasets/PXD042173/PXD042173.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD042173/PXD042173.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD042173/PXD042173.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD042173/PXD042173.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD042173/PXD042173.sdrf.tsv",
       "num_samples": 30,
       "num_columns": 27,
       "organisms": [
@@ -8298,8 +8271,8 @@
       "file": "PXD043473.sdrf.tsv",
       "filename": "PXD043473.sdrf.tsv",
       "path": "datasets/PXD043473/PXD043473.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD043473/PXD043473.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD043473/PXD043473.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD043473/PXD043473.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD043473/PXD043473.sdrf.tsv",
       "num_samples": 129,
       "num_columns": 27,
       "organisms": [
@@ -8307,8 +8280,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Orbitrap Eclipse",
-        "Q Exactive HF"
+        "Q Exactive HF",
+        "Orbitrap Eclipse"
       ],
       "acquisition_methods": [
         "Data-dependent acquisition"
@@ -8323,8 +8296,8 @@
       "file": "PXD045084.sdrf.tsv",
       "filename": "PXD045084.sdrf.tsv",
       "path": "datasets/PXD045084/PXD045084.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD045084/PXD045084.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD045084/PXD045084.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD045084/PXD045084.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD045084/PXD045084.sdrf.tsv",
       "num_samples": 4,
       "num_columns": 27,
       "organisms": [
@@ -8347,8 +8320,8 @@
       "file": "PXD050358.sdrf.tsv",
       "filename": "PXD050358.sdrf.tsv",
       "path": "datasets/PXD050358/PXD050358.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD050358/PXD050358.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD050358/PXD050358.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD050358/PXD050358.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD050358/PXD050358.sdrf.tsv",
       "num_samples": 72,
       "num_columns": 29,
       "organisms": [
@@ -8371,8 +8344,8 @@
       "file": "PXD058808.sdrf.tsv",
       "filename": "PXD058808.sdrf.tsv",
       "path": "datasets/PXD058808/PXD058808.sdrf.tsv",
-      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/dev/datasets/PXD058808/PXD058808.sdrf.tsv",
-      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/dev/datasets/PXD058808/PXD058808.sdrf.tsv",
+      "github_url": "https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/PXD058808/PXD058808.sdrf.tsv",
+      "raw_url": "https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/datasets/PXD058808/PXD058808.sdrf.tsv",
       "num_samples": 48,
       "num_columns": 30,
       "organisms": [
@@ -8380,8 +8353,8 @@
       ],
       "diseases": [],
       "instruments": [
-        "Q Exactive HF-X",
-        "timsTOF Pro 2"
+        "timsTOF Pro 2",
+        "Q Exactive HF-X"
       ],
       "acquisition_methods": [
         "data-dependent acquisition"


### PR DESCRIPTION
## Summary

Follow-up to #819. The SDRF Explorer table is generated by
`site/build-sdrf-index.py`, which was still walking the (now retired)
`annotated-projects/` tree in this repository. Wire it to read from the
external `bigbio/sdrf-annotated-datasets` repo so the deployed site stays in
sync with the canonical home of the annotations.

## Changes

- `site/build-sdrf-index.py` now requires `SDRF_DATASETS_DIR` (path to a
  checkout of `sdrf-annotated-datasets`' `datasets/` folder) and accepts
  `SDRF_DATASETS_REPO` / `SDRF_DATASETS_BRANCH` overrides. Default branch
  flipped from `dev` → `main` (the new repo's default).
- `project_id` is now derived from the path inside `datasets/`, not the spec
  repo's layout, so it works with any checkout location.
- `scripts/build-docs.sh` auto-provisions a shallow clone into `vendor/` when
  `SDRF_DATASETS_DIR` is unset; local dev can point the env var at an existing
  sibling checkout to skip the clone.
- `.gitignore /vendor/` so the provisioned clone never lands in commits.
- Re-ran the script against the live `datasets/` tree: **297 datasets**, URLs
  now resolve to
  `https://github.com/bigbio/sdrf-annotated-datasets/blob/main/datasets/…`
  (and matching raw links). The regenerated `site/sdrf-data.json` and the
  in-sync embedded copy inside `site/sdrf-explorer.html` are in the commit.

## Test plan

- [ ] `SDRF_DATASETS_DIR=/path/to/sdrf-annotated-datasets/datasets python3 site/build-sdrf-index.py` completes and writes `site/sdrf-data.json` with 297 datasets
- [ ] `scripts/build-docs.sh` clones into `vendor/sdrf-annotated-datasets` when `SDRF_DATASETS_DIR` is unset
- [ ] `grep -n 'bigbio/sdrf-annotated-datasets/blob/main' site/sdrf-data.json | head` shows the new URLs

## Related

- Datasets repo: https://github.com/bigbio/sdrf-annotated-datasets
- Original migration PR: #819