### PR TITLE
Sync specification to latest sdrf-templates main

### DIFF
--- a/sdrf-proteomics/README.adoc
+++ b/sdrf-proteomics/README.adoc
@@ -966,7 +966,7 @@ SDRF template with shared sample metadata columns (organism, tissue, disease). T
 | optional
 | Broader anatomical grouping or system-level bucket for the sample, used alongside the organism part for higher-level grouping
 | ontology: uberon, bto
-| digestive system, nervous system, cardiovascular system, gastrointestinal tract
+| heart, liver, brain, gastrointestinal tract
 
 | `characteristics[cell type]`
 | recommended


### PR DESCRIPTION
## Summary
- treat `sdrf-templates` `main` as the source of truth
- bump the `sdrf-templates` submodule from `02dd17e` to the latest `main` commit (`930056b`)
- regenerate the template definitions section in `sdrf-proteomics/README.adoc`

## Validation
- `python3 scripts/generate_templates_appendix.py --templates-dir sdrf-proteomics/sdrf-templates --readme sdrf-proteomics/README.adoc`
- `python3 scripts/build_index_templates.py sdrf-proteomics/sdrf-templates site/index.html`
- `git diff --check`
