### PR TITLE
Rename toggle button class to inherited-toggle-btn

### DIFF
--- a/site/templates/template-page.html.j2
+++ b/site/templates/template-page.html.j2
@@ -67,12 +67,13 @@
             display: flex; align-items: center; gap: 12px;
             margin-bottom: 12px; flex-wrap: wrap;
         }
-        .toggle-btn {
+        .inherited-toggle-btn {
             font-family: inherit; font-size: 0.85rem; font-weight: 500;
             padding: 8px 16px; border-radius: 6px; border: 1px solid var(--border);
             background: var(--bg-alt); color: var(--text); cursor: pointer;
+            white-space: nowrap;
         }
-        .toggle-btn:hover { background: #f0f3f6; border-color: var(--accent); }
+        .inherited-toggle-btn:hover { background: #f0f3f6; border-color: var(--accent); }
         .column-stats { font-size: 0.85rem; color: var(--text-light); }
 
         /* Column table */
@@ -296,7 +297,7 @@
             <h2>Columns</h2>
             <div class="column-controls">
                 {% if inherited_cols %}
-                <button class="toggle-btn" id="toggle-inherited" onclick="toggleInherited()">
+                <button class="inherited-toggle-btn" id="toggle-inherited" onclick="toggleInherited()">
                     Show inherited columns ({{ inherited_cols | length }})
                 </button>
                 {% endif %}


### PR DESCRIPTION
## Summary
Refactored the CSS class name for the inherited columns toggle button from a generic `toggle-btn` to a more specific `inherited-toggle-btn` to better reflect its purpose and improve code clarity.

## Key Changes
- Renamed `.toggle-btn` CSS class to `.inherited-toggle-btn` for better semantic naming
- Updated corresponding hover state selector from `.toggle-btn:hover` to `.inherited-toggle-btn:hover`
- Updated HTML button element to use the new class name
- Added `white-space: nowrap;` property to prevent button text wrapping

## Implementation Details
This change improves code maintainability by using a more descriptive class name that clearly indicates this button is specifically for toggling inherited columns visibility. The addition of `white-space: nowrap;` ensures the button label remains on a single line, improving the UI layout consistency.

https://claude.ai/code/session_013BVHtZtabrLE9Zp8m9yxCB