### PR TITLE
Clarify proteomics data acquisition method under PRIDE:0000659

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Proteomics data acquisition method policy** (`comment[proteomics data acquisition method]`): values MUST be descendants of [`PRIDE:0000659`](https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000659); recommend lowercase OLS labels and `NT=<label>;AC=<accession>`; plain free-text OLS labels remain allowed. Recommended SRM accession is `PRIDE:0000630` (not `MS:1000206`). See [#843](https://github.com/bigbio/proteomics-sample-metadata/issues/843) and [sdrf-annotated-datasets#31](https://github.com/bigbio/sdrf-annotated-datasets/issues/31).
+- **Proteomics data acquisition method policy** (`comment[proteomics data acquisition method]`): values MUST be descendants of [`PRIDE:0000659`](https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000659); recommend `NT=<OLS label>;AC=<accession>` using the OLS label as written; plain free-text OLS labels remain allowed. DIA variants (diaPASEF, SWATH MS) are recorded in this same column as PRIDE:0000659 descendants (`comment[dia method]` is no longer a template column). Recommended SRM accession is `PRIDE:0000630` (not `MS:1000206`). See [#843](https://github.com/bigbio/proteomics-sample-metadata/issues/843) and [sdrf-annotated-datasets#31](https://github.com/bigbio/sdrf-annotated-datasets/issues/31).
 
 - **Organism part / sampling site guidance**: clarified that `characteristics[organism part]` is the main normalized anatomy field for cross-study integration, while `characteristics[sampling site]` captures provenance or finer local context and may be equal to `characteristics[organism part]`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Proteomics data acquisition method policy** (`comment[proteomics data acquisition method]`): values MUST be descendants of [`PRIDE:0000659`](http://purl.obolibrary.org/obo/PRIDE_0000659); recommend lowercase OLS labels and `NT=<label>;AC=<accession>`; plain free-text OLS labels remain allowed. Recommended SRM accession is `PRIDE:0000630` (not `MS:1000206`). See [#843](https://github.com/bigbio/proteomics-sample-metadata/issues/843) and [sdrf-annotated-datasets#31](https://github.com/bigbio/sdrf-annotated-datasets/issues/31).
+
 - **Organism part / sampling site guidance**: clarified that `characteristics[organism part]` is the main normalized anatomy field for cross-study integration, while `characteristics[sampling site]` captures provenance or finer local context and may be equal to `characteristics[organism part]`.
 
 - **Template architecture refactoring**: Introduced `sample-metadata` intermediate template between `base` and technology/organism templates. Columns `organism`, `organism part`, `cell type`, `biological replicate`, and `pooled sample` moved from `base` to `sample-metadata`. Columns `disease` and `biosample accession number` consolidated from organism templates into `sample-metadata` (RECOMMENDED and OPTIONAL respectively; organism templates override disease to REQUIRED). All technology templates (`ms-proteomics`, `affinity-proteomics`) and organism templates (`human`, `vertebrates`, `invertebrates`, `plants`) now extend `sample-metadata` instead of `base`. No change to effective validation for any template combination.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Proteomics data acquisition method policy** (`comment[proteomics data acquisition method]`): values MUST be descendants of [`PRIDE:0000659`](http://purl.obolibrary.org/obo/PRIDE_0000659); recommend lowercase OLS labels and `NT=<label>;AC=<accession>`; plain free-text OLS labels remain allowed. Recommended SRM accession is `PRIDE:0000630` (not `MS:1000206`). See [#843](https://github.com/bigbio/proteomics-sample-metadata/issues/843) and [sdrf-annotated-datasets#31](https://github.com/bigbio/sdrf-annotated-datasets/issues/31).
+- **Proteomics data acquisition method policy** (`comment[proteomics data acquisition method]`): values MUST be descendants of [`PRIDE:0000659`](https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000659); recommend lowercase OLS labels and `NT=<label>;AC=<accession>`; plain free-text OLS labels remain allowed. Recommended SRM accession is `PRIDE:0000630` (not `MS:1000206`). See [#843](https://github.com/bigbio/proteomics-sample-metadata/issues/843) and [sdrf-annotated-datasets#31](https://github.com/bigbio/sdrf-annotated-datasets/issues/31).
 
 - **Organism part / sampling site guidance**: clarified that `characteristics[organism part]` is the main normalized anatomy field for cross-study integration, while `characteristics[sampling site]` captures provenance or finer local context and may be equal to `characteristics[organism part]`.
 

--- a/sdrf-proteomics/README.adoc
+++ b/sdrf-proteomics/README.adoc
@@ -461,7 +461,7 @@ NOTE: For HCD (Higher-energy C-trap Dissociation), the canonical accession is ht
 
 Proteomics data acquisition method can happen in multiple ways: Data Dependent Acquisition (DDA), Data Independent Acquisition (DIA), and targeted approaches. The SDRF-Proteomics file format REQUIRES capturing the method used for the data acquisition in the _comment[proteomics data acquisition method]_ column.
 
-The values MUST identify a **descendant** of the PRIDE ontology term https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000659[proteomics data acquisition method (PRIDE:0000659)] (`http://purl.obolibrary.org/obo/PRIDE_0000659`).
+The values MUST identify a **descendant** of the PRIDE ontology term https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000659[proteomics data acquisition method (PRIDE:0000659)].
 
 Recommended encoding:
 

--- a/sdrf-proteomics/README.adoc
+++ b/sdrf-proteomics/README.adoc
@@ -459,14 +459,35 @@ NOTE: For HCD (Higher-energy C-trap Dissociation), the canonical accession is ht
 [[data-acquisition-method]]
 === Proteomics data acquisition method
 
-Proteomics data acquisition method can happen in multiple ways: Data Dependent Acquisition (DDA), Data Independent Acquisition (DIA), and targeted approaches. The SDRF-Proteomics file format REQUIRES capturing the method used for the data acquisition in the _comment[proteomics data acquisition method]_ column. The values MUST be children of the PRIDE ontology term https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000659[proteomics data acquisition method (PRIDE:0000659)]. The following values are commonly used:
+Proteomics data acquisition method can happen in multiple ways: Data Dependent Acquisition (DDA), Data Independent Acquisition (DIA), and targeted approaches. The SDRF-Proteomics file format REQUIRES capturing the method used for the data acquisition in the _comment[proteomics data acquisition method]_ column.
 
-* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000627[data-dependent acquisition]
-* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000450[data-independent acquisition]
-  - https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000650?lang=en[diaPASEF]
-  - https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000447[SWATH MS]
-* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000629[parallel reaction monitoring]
-* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000630[selected reaction monitoring]
+The values MUST identify a **descendant** of the PRIDE ontology term https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000659[proteomics data acquisition method (PRIDE:0000659)] (`http://purl.obolibrary.org/obo/PRIDE_0000659`).
+
+Recommended encoding:
+
+* Prefer lowercase OLS labels
+* Prefer `NT=<lowercase OLS label>;AC=<matching accession>`
+* Plain free-text OLS labels are also allowed when they match a descendant of `PRIDE:0000659`
+
+Common recommended values:
+
+[cols="1,3", options="header"]
+|===
+| Method | Recommended value
+| DDA | `NT=data-dependent acquisition;AC=PRIDE:0000627`
+| DIA | `NT=data-independent acquisition;AC=PRIDE:0000450`
+| PRM | `NT=parallel reaction monitoring;AC=PRIDE:0000629`
+| SRM | `NT=selected reaction monitoring;AC=PRIDE:0000630`
+|===
+
+Other descendants remain valid when that is the true acquisition method, for example:
+
+* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000650?lang=en[diaPASEF]
+* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000447[SWATH MS]
+
+Finer DIA method detail may also be captured in _comment[dia method]_ when the top-level acquisition method is DIA.
+
+Do **not** use non-PRIDE accessions for this column (for example `MS:1000206`, `MS:1003221`, or `NCIT:C161786`).
 
 IMPORTANT: The _comment[proteomics data acquisition method]_ column is REQUIRED for all mass spectrometry-based SDRF files. This field must be explicitly specified and cannot be omitted or assumed.
 
@@ -1062,7 +1083,7 @@ Base SDRF template for mass spectrometry-based proteomics. This is the minimum v
 | required
 | Mass spectrometry acquisition method
 | ontology: pride
-| data-dependent acquisition, data-independent acquisition, parallel reaction monitoring, selected reaction monitoring
+| NT=data-dependent acquisition;AC=PRIDE:0000627, NT=data-independent acquisition;AC=PRIDE:0000450, NT=parallel reaction monitoring;AC=PRIDE:0000629, NT=selected reaction monitoring;AC=PRIDE:0000630
 
 | `comment[instrument]`
 | required
@@ -1733,8 +1754,8 @@ SDRF template for Data-independent acquisition (DIA) experiments. Extends ms-pro
 | `comment[proteomics data acquisition method]`
 | required
 | Mass spectrometry acquisition method (restricted to DIA for this template)
-| single value only; values: Data-independent acquisition
-|
+| single value only; ontology: pride; values: data-independent acquisition, NT=data-independent acquisition;AC=PRIDE:0000450, diaPASEF, SWATH MS (plain or NT+AC)
+| NT=data-independent acquisition;AC=PRIDE:0000450
 
 | `comment[scan window lower limit]`
 | recommended

--- a/sdrf-proteomics/README.adoc
+++ b/sdrf-proteomics/README.adoc
@@ -80,9 +80,9 @@ Here's a minimal example:
 |===
 |source name |characteristics[organism] |characteristics[organism part] |characteristics[disease] |characteristics[biological replicate] |assay name |technology type |comment[proteomics data acquisition method] |comment[label] |comment[instrument] |comment[cleavage agent details] |comment[fraction identifier] |comment[technical replicate] |comment[data file] |factor value[disease]
 
-|sample_1 |homo sapiens |liver |normal |1 |run_1 |proteomic profiling by mass spectrometry |data-dependent acquisition |label free sample |Q Exactive HF |NT=Trypsin;AC=MS:1001251 |1 |1 |sample_1.raw |normal
-|sample_2 |homo sapiens |liver |hepatocellular carcinoma |1 |run_2 |proteomic profiling by mass spectrometry |data-dependent acquisition |label free sample |Q Exactive HF |NT=Trypsin;AC=MS:1001251 |1 |1 |sample_2.raw |hepatocellular carcinoma
-|sample_3 |homo sapiens |not available |not available |1 |run_3 |proteomic profiling by mass spectrometry |data-dependent acquisition |label free sample |Q Exactive HF |NT=Trypsin;AC=MS:1001251 |1 |1 |sample_3.raw |not available
+|sample_1 |homo sapiens |liver |normal |1 |run_1 |proteomic profiling by mass spectrometry |Data-dependent acquisition |label free sample |Q Exactive HF |NT=Trypsin;AC=MS:1001251 |1 |1 |sample_1.raw |normal
+|sample_2 |homo sapiens |liver |hepatocellular carcinoma |1 |run_2 |proteomic profiling by mass spectrometry |Data-dependent acquisition |label free sample |Q Exactive HF |NT=Trypsin;AC=MS:1001251 |1 |1 |sample_2.raw |hepatocellular carcinoma
+|sample_3 |homo sapiens |not available |not available |1 |run_3 |proteomic profiling by mass spectrometry |Data-dependent acquisition |label free sample |Q Exactive HF |NT=Trypsin;AC=MS:1001251 |1 |1 |sample_3.raw |not available
 |===
 
 The file is organized into three column sections:
@@ -408,7 +408,7 @@ Example:
 |===
 |source name |assay name |technology type |comment[proteomics data acquisition method] |comment[label] |comment[instrument] |comment[data file]
 
-|sample_1 |sample1_run1 |proteomic profiling by mass spectrometry |data-dependent acquisition |label free sample |Q Exactive HF |sample1.raw
+|sample_1 |sample1_run1 |proteomic profiling by mass spectrometry |Data-dependent acquisition |label free sample |Q Exactive HF |sample1.raw
 |===
 
 [[multi-file-formats]]
@@ -465,8 +465,8 @@ The values MUST identify a **descendant** of the PRIDE ontology term https://www
 
 Recommended encoding:
 
-* Prefer lowercase OLS labels
-* Prefer `NT=<lowercase OLS label>;AC=<matching accession>`
+* Use the OLS label as written (do not force lowercase or Title Case)
+* Prefer `NT=<OLS label>;AC=<matching accession>`
 * Plain free-text OLS labels are also allowed when they match a descendant of `PRIDE:0000659`
 
 Common recommended values:
@@ -474,18 +474,16 @@ Common recommended values:
 [cols="1,3", options="header"]
 |===
 | Method | Recommended value
-| DDA | `NT=data-dependent acquisition;AC=PRIDE:0000627`
-| DIA | `NT=data-independent acquisition;AC=PRIDE:0000450`
-| PRM | `NT=parallel reaction monitoring;AC=PRIDE:0000629`
-| SRM | `NT=selected reaction monitoring;AC=PRIDE:0000630`
+| DDA | `NT=Data-dependent acquisition;AC=PRIDE:0000627`
+| DIA | `NT=Data-independent acquisition;AC=PRIDE:0000450`
+| PRM | `NT=Parallel reaction monitoring;AC=PRIDE:0000629`
+| SRM | `NT=Selected reaction monitoring;AC=PRIDE:0000630`
 |===
 
-Other descendants remain valid when that is the true acquisition method, for example:
+Other descendants remain valid when that is the true acquisition method, and are recorded in this same column, for example:
 
-* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000650?lang=en[diaPASEF]
-* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000447[SWATH MS]
-
-Finer DIA method detail may also be captured in _comment[dia method]_ when the top-level acquisition method is DIA.
+* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000650?lang=en[diaPASEF] — `NT=diaPASEF;AC=PRIDE:0000650`
+* https://www.ebi.ac.uk/ols4/ontologies/pride/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FPRIDE_0000447[SWATH MS] — `NT=SWATH MS;AC=PRIDE:0000447`
 
 Do **not** use non-PRIDE accessions for this column (for example `MS:1000206`, `MS:1003221`, or `NCIT:C161786`).
 
@@ -867,7 +865,7 @@ The following table provides links to example SDRF files for different experimen
 
 |DIA
 |PXD018830
-|data-independent acquisition
+|Data-independent acquisition
 |link:sdrf-explorer.html?view=PXD018830[View in Explorer]
 |https://github.com/bigbio/sdrf-annotated-datasets/tree/main/datasets/PXD018830[GitHub]
 
@@ -1083,7 +1081,7 @@ Base SDRF template for mass spectrometry-based proteomics. This is the minimum v
 | required
 | Mass spectrometry acquisition method
 | ontology: pride
-| NT=data-dependent acquisition;AC=PRIDE:0000627, NT=data-independent acquisition;AC=PRIDE:0000450, NT=parallel reaction monitoring;AC=PRIDE:0000629, NT=selected reaction monitoring;AC=PRIDE:0000630
+| NT=Data-dependent acquisition;AC=PRIDE:0000627, NT=Data-independent acquisition;AC=PRIDE:0000450, NT=Parallel reaction monitoring;AC=PRIDE:0000629, NT=Selected reaction monitoring;AC=PRIDE:0000630
 
 | `comment[instrument]`
 | required
@@ -1754,8 +1752,8 @@ SDRF template for Data-independent acquisition (DIA) experiments. Extends ms-pro
 | `comment[proteomics data acquisition method]`
 | required
 | Mass spectrometry acquisition method (restricted to DIA for this template)
-| single value only; ontology: pride; values: data-independent acquisition, NT=data-independent acquisition;AC=PRIDE:0000450, diaPASEF, SWATH MS (plain or NT+AC)
-| NT=data-independent acquisition;AC=PRIDE:0000450
+| single value only; ontology: pride; values: Data-independent acquisition, NT=Data-independent acquisition;AC=PRIDE:0000450, diaPASEF, SWATH MS (plain or NT+AC)
+| NT=Data-independent acquisition;AC=PRIDE:0000450
 
 | `comment[scan window lower limit]`
 | recommended
@@ -1774,12 +1772,6 @@ SDRF template for Data-independent acquisition (DIA) experiments. Extends ms-pro
 | Width of the isolation window in m/z units
 | pattern: Width in m/z
 | 25, 8, 4
-
-| `comment[dia method]`
-| recommended
-| Specific DIA method variant used
-| ontology: pride
-| SWATH-MS, MSE, All ion fragmentation, diaPASEF
 
 |===
 
@@ -3458,7 +3450,7 @@ Base SDRF template for mass spectrometry-based metabolomics. This is the parent 
 | required
 | Mass spectrometry acquisition method (DDA, DIA, SIM, MRM, full scan)
 | ontology: pride
-| data-dependent acquisition, data-independent acquisition, selected reaction monitoring, parallel reaction monitoring, ...
+| Data-dependent acquisition, Data-independent acquisition, Selected reaction monitoring, Parallel reaction monitoring, ...
 
 | `comment[metabolite assignment file]`
 | recommended

--- a/sdrf-proteomics/quickstart.adoc
+++ b/sdrf-proteomics/quickstart.adoc
@@ -333,7 +333,7 @@ Here's a minimum valid SDRF file for a human liver cancer study, including all r
 |male
 |run_001
 |proteomic profiling by mass spectrometry
-|Data-dependent acquisition
+|NT=data-dependent acquisition;AC=PRIDE:0000627
 |label free sample
 |Q Exactive HF
 |NT=Trypsin;AC=MS:1001251
@@ -351,7 +351,7 @@ Here's a minimum valid SDRF file for a human liver cancer study, including all r
 |female
 |run_002
 |proteomic profiling by mass spectrometry
-|Data-dependent acquisition
+|NT=data-dependent acquisition;AC=PRIDE:0000627
 |label free sample
 |Q Exactive HF
 |NT=Trypsin;AC=MS:1001251
@@ -369,7 +369,7 @@ Here's a minimum valid SDRF file for a human liver cancer study, including all r
 |male
 |run_003
 |proteomic profiling by mass spectrometry
-|Data-dependent acquisition
+|NT=data-dependent acquisition;AC=PRIDE:0000627
 |label free sample
 |Q Exactive HF
 |NT=Trypsin;AC=MS:1001251
@@ -387,7 +387,7 @@ Here's a minimum valid SDRF file for a human liver cancer study, including all r
 |female
 |run_004
 |proteomic profiling by mass spectrometry
-|Data-dependent acquisition
+|NT=data-dependent acquisition;AC=PRIDE:0000627
 |label free sample
 |Q Exactive HF
 |NT=Trypsin;AC=MS:1001251

--- a/sdrf-proteomics/quickstart.adoc
+++ b/sdrf-proteomics/quickstart.adoc
@@ -333,7 +333,7 @@ Here's a minimum valid SDRF file for a human liver cancer study, including all r
 |male
 |run_001
 |proteomic profiling by mass spectrometry
-|NT=data-dependent acquisition;AC=PRIDE:0000627
+|NT=Data-dependent acquisition;AC=PRIDE:0000627
 |label free sample
 |Q Exactive HF
 |NT=Trypsin;AC=MS:1001251
@@ -351,7 +351,7 @@ Here's a minimum valid SDRF file for a human liver cancer study, including all r
 |female
 |run_002
 |proteomic profiling by mass spectrometry
-|NT=data-dependent acquisition;AC=PRIDE:0000627
+|NT=Data-dependent acquisition;AC=PRIDE:0000627
 |label free sample
 |Q Exactive HF
 |NT=Trypsin;AC=MS:1001251
@@ -369,7 +369,7 @@ Here's a minimum valid SDRF file for a human liver cancer study, including all r
 |male
 |run_003
 |proteomic profiling by mass spectrometry
-|NT=data-dependent acquisition;AC=PRIDE:0000627
+|NT=Data-dependent acquisition;AC=PRIDE:0000627
 |label free sample
 |Q Exactive HF
 |NT=Trypsin;AC=MS:1001251
@@ -387,7 +387,7 @@ Here's a minimum valid SDRF file for a human liver cancer study, including all r
 |female
 |run_004
 |proteomic profiling by mass spectrometry
-|NT=data-dependent acquisition;AC=PRIDE:0000627
+|NT=Data-dependent acquisition;AC=PRIDE:0000627
 |label free sample
 |Q Exactive HF
 |NT=Trypsin;AC=MS:1001251


### PR DESCRIPTION
## Summary
- Update the SDRF-Proteomics acquisition-method section so values MUST be descendants of [`PRIDE:0000659`](http://purl.obolibrary.org/obo/PRIDE_0000659).
- Recommend lowercase OLS labels and `NT=<label>;AC=<accession>`; plain free-text OLS labels remain allowed.
- Align ms-proteomics / dia-acquisition examples and quickstart sample rows with the recommended forms (SRM stays `PRIDE:0000630`).

Fixes #843
Related: bigbio/sdrf-annotated-datasets#31, bigbio/sdrf-templates#53 / https://github.com/bigbio/sdrf-templates/pull/54, bigbio/sdrf-pipelines#336

## Notes
- Template YAML source changes are in [sdrf-templates#54](https://github.com/bigbio/sdrf-templates/pull/54). This PR updates the spec narrative and embedded docs; a submodule pointer bump can follow once that PR merges.

## Test plan
- [ ] Review [[data-acquisition-method]] wording for MUST / SHOULD / MAY clarity
- [ ] Confirm recommended table uses PRIDE accessions only
- [ ] Confirm quickstart examples use `NT=data-dependent acquisition;AC=PRIDE:0000627`
- [ ] Confirm dia-acquisition embedded table no longer requires Title-Case plain DIA only


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated proteomics data-acquisition guidance to use PRIDE ontology terms and structured `NT`/`AC` values.
  * Added standard encodings for DDA, DIA, PRM, and SRM methods, including supported DIA variants.
  * Updated MS-proteomics templates and quickstart examples with ontology-annotated acquisition methods.
  * Clarified that valid descendant terms are permitted while non-PRIDE accessions are not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->